### PR TITLE
Bugfix the render instance without workfile being saved

### DIFF
--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -2,6 +2,7 @@
 import bpy
 
 from ayon_core.lib import version_up
+from ayon_core.pipeline.context_tools import version_up_current_workfile
 from ayon_blender.api import plugin
 from ayon_blender.api.render_lib import prepare_rendering
 from ayon_blender.api.workio import save_file
@@ -39,7 +40,10 @@ class CreateRenderlayer(plugin.BlenderCreator):
         # settings. Even the validator to check that the file is saved will
         # detect the file as saved, even if it isn't. The only solution for
         # now it is to force the file to be saved.
-        filepath = version_up(bpy.data.filepath)
-        save_file(filepath, copy=False)
+        if not bpy.data.filepath:
+            version_up_current_workfile()
+        else:
+            filepath = version_up(bpy.data.filepath)
+            save_file(filepath, copy=False)
 
         return collection


### PR DESCRIPTION
### Changelog Description
Resolve #3 

### Testing Notes
1. Launch Blender 
2. Create Render Instance
3. It should be saving the new scene for creating render instance if there is no workfile saved.
 