### PR TITLE
Fix QApplication access on platforms other than Windows

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -195,7 +195,7 @@ def _process_app_events() -> Optional[float]:
             return TIMER_INTERVAL
 
         app = GlobalClass.app
-        if app._instance:
+        if app:
             app.processEvents()
             return TIMER_INTERVAL
     return TIMER_INTERVAL

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -248,7 +248,7 @@ class LaunchQtApp(bpy.types.Operator):
         if not isinstance(self._window, (QtWidgets.QWidget, ModuleType)):
             raise AttributeError(
                 "`window` should be a `QWidget or module`. Got: {}".format(
-                    str(type(window))
+                    str(type(self._window))
                 )
             )
 


### PR DESCRIPTION
### Issue

This PR #7 introduced changes to how the QApplication is generated and accessed - however it seems I missed one that was only called on non-windows platforms, which of course I didn't test on.

This PR should fix the bug reported [here](https://community.ynput.io/t/setting-up-blender-4-2-linux-mint-error-with-the-ayon-operators/1574/11) and with that should also fix the current `ayon-blender` state for Mac/Linux.

Original error:
```python
Traceback (most recent call last):
  File "/home/hannah/.local/share/AYON/addons/blender_0.2.1-dev.1/ayon_blender/api/ops.py", line 198, in _process_app_events
    if app._instance:
       ^^^^^^^^^^^^^
AttributeError: 'PySide6.QtWidgets.QApplication' object has no attribute '_instance'
```

### Testing Notes

1. Run Blender on non-windows platform
2. Make sure the AYON Qt tools work as intended.

@HannahFantasia can you test run this?