### PR TITLE
Do not error on unsaved workfile

### DIFF
--- a/client/ayon_blender/plugins/publish/collect_workfile.py
+++ b/client/ayon_blender/plugins/publish/collect_workfile.py
@@ -16,7 +16,7 @@ class CollectWorkfile(plugin.BlenderInstancePlugin):
         """Process collector."""
 
         context = instance.context
-        filepath = Path(context.data["currentFile"])
+        filepath = Path(context.data.get("currentFile") or "")
         ext = filepath.suffix
 
         instance.data.update(

--- a/client/ayon_blender/plugins/publish/collect_workfile.py
+++ b/client/ayon_blender/plugins/publish/collect_workfile.py
@@ -16,7 +16,15 @@ class CollectWorkfile(plugin.BlenderInstancePlugin):
         """Process collector."""
 
         context = instance.context
-        filepath = Path(context.data.get("currentFile") or "")
+        filepath = context.data.get("currentFile")
+        if not filepath:
+            self.log.warning("Deactivating workfile instance because no "
+                             "current filepath is found. Please save your "
+                             "workfile.")
+            instance.data["publish"] = False
+            return
+
+        filepath = Path(filepath)
         ext = filepath.suffix
 
         instance.data.update(


### PR DESCRIPTION
This is an extension of another PR in ayon-core: https://github.com/ynput/ayon-core/pull/786

Together they generate a better validation report for when the publish started from an unsaved workfile.

![image](https://github.com/user-attachments/assets/c488d0e9-c4f6-477d-8db3-5424b95f0fb2)
