### PR TITLE
add set unit scale options into AYON menu

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -430,7 +430,11 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.separator()
         layout.operator(SetFrameRange.bl_idname, text="Set Frame Range")
         layout.operator(SetResolution.bl_idname, text="Set Resolution")
-        layout.operator(SetUnitScale.bl_idname, text="Set Unit Scale")
+        project = os.environ.get("AYON_PROJECT_NAME")
+        settings = get_project_settings(project).get("blender")
+        unit_scale_settings = settings.get("unit_scale_settings")
+        if unit_scale_settings.get("enabled"):
+            layout.operator(SetUnitScale.bl_idname, text="Set Unit Scale")
         layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
 

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -387,7 +387,7 @@ class SetUnitScale(bpy.types.Operator):
         project = os.environ.get("AYON_PROJECT_NAME")
         settings = get_project_settings(project).get("blender")
         unit_scale_settings = settings.get("unit_scale_settings")
-        pipeline.set_unit_scale_for_setting(
+        pipeline.set_unit_scale_from_settings(
             unit_scale_settings=unit_scale_settings)
         return {"FINISHED"}
 
@@ -431,11 +431,7 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.separator()
         layout.operator(SetFrameRange.bl_idname, text="Set Frame Range")
         layout.operator(SetResolution.bl_idname, text="Set Resolution")
-        project = os.environ.get("AYON_PROJECT_NAME")
-        settings = get_project_settings(project).get("blender")
-        unit_scale_settings = settings.get("unit_scale_settings")
-        if unit_scale_settings.get("enabled"):
-            layout.operator(SetUnitScale.bl_idname, text="Set Unit Scale")
+        layout.operator(SetUnitScale.bl_idname, text="Set Unit Scale")
         layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
 

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -187,9 +187,6 @@ def _process_app_events() -> Optional[float]:
 
         # Refresh Manager
         if GlobalClass.app:
-           if not hasattr(GlobalClass.app, "get_window"):
-                GlobalClass.app.processEvents()
-                return TIMER_INTERVAL
            manager = GlobalClass.app.get_window("WM_OT_avalon_manager")
            if manager:
                manager.refresh()
@@ -390,7 +387,8 @@ class SetUnitScale(bpy.types.Operator):
         project = os.environ.get("AYON_PROJECT_NAME")
         settings = get_project_settings(project).get("blender")
         unit_scale_settings = settings.get("unit_scale_settings")
-        pipeline.set_unit_scale(unit_scale_settings)
+        pipeline.set_unit_scale_for_setting(
+            unit_scale_settings=unit_scale_settings)
         return {"FINISHED"}
 
 

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -187,9 +187,12 @@ def _process_app_events() -> Optional[float]:
 
         # Refresh Manager
         if GlobalClass.app:
-            manager = GlobalClass.app.get_window("WM_OT_avalon_manager")
-            if manager:
-                manager.refresh()
+           if not hasattr(GlobalClass.app, "get_window"):
+                GlobalClass.app.processEvents()
+                return TIMER_INTERVAL
+           manager = GlobalClass.app.get_window("WM_OT_avalon_manager")
+           if manager:
+               manager.refresh()
 
     if not GlobalClass.is_windows:
         if OpenFileCacher.opening_file:

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -16,6 +16,7 @@ import bpy
 import bpy.utils.previews
 
 from ayon_core import style
+from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import get_current_folder_path, get_current_task_name
 from ayon_core.pipeline.context_tools import (
     get_current_task_entity
@@ -378,6 +379,17 @@ class SetResolution(bpy.types.Operator):
         pipeline.set_resolution(data)
         return {"FINISHED"}
 
+class SetUnitScale(bpy.types.Operator):
+    bl_idname = "wm.ayon_set_unit_scale"
+    bl_label = "Set Unit Scale"
+
+    def execute(self, context):
+        project = os.environ.get("AYON_PROJECT_NAME")
+        settings = get_project_settings(project).get("blender")
+        unit_scale_settings = settings.get("unit_scale_settings")
+        pipeline.set_unit_scale(unit_scale_settings)
+        return {"FINISHED"}
+
 
 class TOPBAR_MT_avalon(bpy.types.Menu):
     """Avalon menu."""
@@ -418,6 +430,7 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.separator()
         layout.operator(SetFrameRange.bl_idname, text="Set Frame Range")
         layout.operator(SetResolution.bl_idname, text="Set Resolution")
+        layout.operator(SetUnitScale.bl_idname, text="Set Unit Scale")
         layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
 
@@ -437,6 +450,7 @@ classes = [
     LaunchWorkFiles,
     SetFrameRange,
     SetResolution,
+    SetUnitScale,
     TOPBAR_MT_avalon,
 ]
 

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -17,7 +17,11 @@ import bpy.utils.previews
 
 from ayon_core import style
 from ayon_core.settings import get_project_settings
-from ayon_core.pipeline import get_current_folder_path, get_current_task_name
+from ayon_core.pipeline import (
+    get_current_folder_path,
+    get_current_task_name,
+    get_current_project_name
+)
 from ayon_core.pipeline.context_tools import (
     get_current_task_entity
 )
@@ -187,9 +191,9 @@ def _process_app_events() -> Optional[float]:
 
         # Refresh Manager
         if GlobalClass.app:
-           manager = GlobalClass.app.get_window("WM_OT_avalon_manager")
-           if manager:
-               manager.refresh()
+            manager = GlobalClass.app.get_window("WM_OT_avalon_manager")
+            if manager:
+                manager.refresh()
 
     if not GlobalClass.is_windows:
         if OpenFileCacher.opening_file:
@@ -379,12 +383,13 @@ class SetResolution(bpy.types.Operator):
         pipeline.set_resolution(data)
         return {"FINISHED"}
 
+
 class SetUnitScale(bpy.types.Operator):
     bl_idname = "wm.ayon_set_unit_scale"
     bl_label = "Set Unit Scale"
 
     def execute(self, context):
-        project = os.environ.get("AYON_PROJECT_NAME")
+        project = get_current_project_name()
         settings = get_project_settings(project).get("blender")
         unit_scale_settings = settings.get("unit_scale_settings")
         pipeline.set_unit_scale_from_settings(

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -296,6 +296,15 @@ def set_resolution(data):
     scene.render.resolution_y = resolution_y
 
 
+def set_unit_scale(unit_scale_settings=None):
+    if unit_scale_settings is None:
+        return
+    unit_scale_enabled = unit_scale_settings.get("enabled")
+    if unit_scale_enabled:
+        unit_scale = unit_scale_settings.get("base_file_unit_scale")
+        bpy.context.scene.unit_settings.scale_length = unit_scale
+
+
 def on_new():
     project = os.environ.get("AYON_PROJECT_NAME")
     settings = get_project_settings(project).get("blender")
@@ -311,10 +320,7 @@ def on_new():
         set_frame_range(data)
 
     unit_scale_settings = settings.get("unit_scale_settings")
-    unit_scale_enabled = unit_scale_settings.get("enabled")
-    if unit_scale_enabled:
-        unit_scale = unit_scale_settings.get("base_file_unit_scale")
-        bpy.context.scene.unit_settings.scale_length = unit_scale
+    set_unit_scale(unit_scale_settings=unit_scale_settings)
 
 
 def on_open():

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -22,6 +22,7 @@ from ayon_core.pipeline import (
     deregister_creator_plugin_path,
     AVALON_CONTAINER_ID,
     AYON_CONTAINER_ID,
+    get_current_project_name
 )
 from ayon_core.pipeline.context_tools import (
     get_current_task_entity
@@ -296,7 +297,7 @@ def set_resolution(data):
     scene.render.resolution_y = resolution_y
 
 
-def set_unit_scale_for_setting(unit_scale_settings=None):
+def set_unit_scale_from_settings(unit_scale_settings=None):
     if unit_scale_settings is None:
         return
     unit_scale_enabled = unit_scale_settings.get("enabled")
@@ -306,7 +307,7 @@ def set_unit_scale_for_setting(unit_scale_settings=None):
 
 
 def on_new():
-    project = os.environ.get("AYON_PROJECT_NAME")
+    project = get_current_project_name()
     settings = get_project_settings(project).get("blender")
 
     set_resolution_startup = settings.get("set_resolution_startup")
@@ -320,7 +321,7 @@ def on_new():
         set_frame_range(data)
 
     unit_scale_settings = settings.get("unit_scale_settings")
-    set_unit_scale_for_setting(unit_scale_settings=unit_scale_settings)
+    set_unit_scale_from_settings(unit_scale_settings=unit_scale_settings)
 
 
 def on_open():

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -302,7 +302,7 @@ def set_unit_scale_from_settings(unit_scale_settings=None):
         return
     unit_scale_enabled = unit_scale_settings.get("enabled")
     if unit_scale_enabled:
-        unit_scale = unit_scale_settings.get("base_file_unit_scale")
+        unit_scale = unit_scale_settings["base_file_unit_scale"]
         bpy.context.scene.unit_settings.scale_length = unit_scale
 
 

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -296,7 +296,7 @@ def set_resolution(data):
     scene.render.resolution_y = resolution_y
 
 
-def set_unit_scale(unit_scale_settings=None):
+def set_unit_scale_for_setting(unit_scale_settings=None):
     if unit_scale_settings is None:
         return
     unit_scale_enabled = unit_scale_settings.get("enabled")
@@ -320,7 +320,7 @@ def on_new():
         set_frame_range(data)
 
     unit_scale_settings = settings.get("unit_scale_settings")
-    set_unit_scale(unit_scale_settings=unit_scale_settings)
+    set_unit_scale_for_setting(unit_scale_settings=unit_scale_settings)
 
 
 def on_open():


### PR DESCRIPTION
## Changelog Description
This PR is to add unit scale options into AYON menu


## Additional info
Make sure to turn on `ayon+settings://blender/unit_scale_settings/enabled` 
![image](https://github.com/user-attachments/assets/457108aa-adb9-4318-9465-604060a01ea3)

We need to consider whether `ayon+settings://blender/unit_scale_settings/apply_on_opening` is required for some enhancement, as the window of log message does not show on top.

![image](https://github.com/user-attachments/assets/afc54b58-727e-4097-8078-49173f83fb2e)

## Testing notes:

1. Launch Blender
2. AYON -> Set Unit Scale
![image](https://github.com/user-attachments/assets/fc4e1a9f-de77-4471-a33f-19a0b25a0f5a)
