### PR TITLE
Add a check on scene render filepath and repair action in Validate Render Output for Deadline

### DIFF
--- a/client/ayon_blender/plugins/publish/validate_deadline_publish.py
+++ b/client/ayon_blender/plugins/publish/validate_deadline_publish.py
@@ -31,6 +31,22 @@ class ValidateDeadlinePublish(
         if not self.is_active(instance.data):
             return
 
+        invalid = self.get_invalid(instance)
+        if invalid:
+            bullet_point_invalid_statement = "\n".join(
+                "- {}".format(err) for err in invalid
+            )
+            report = (
+                "Render Output has invalid values(s).\n\n"
+                f"{bullet_point_invalid_statement}\n\n"
+            )
+            raise PublishValidationError(
+                report,
+                title="Invalid value(s) for Render Output")
+
+    @classmethod
+    def get_invalid(cls, instance):
+        invalid = []
         tree = bpy.context.scene.node_tree
         output_type = "CompositorNodeOutputFile"
         output_node = None
@@ -41,21 +57,30 @@ class ValidateDeadlinePublish(
                 output_node = node
                 break
         if not output_node:
-            raise PublishValidationError(
-                "No output node found in the compositor tree."
-            )
+            msg = "No output node found in the compositor tree."
+            invalid.append(msg)
+
         filepath = bpy.data.filepath
         file = os.path.basename(filepath)
         filename, ext = os.path.splitext(file)
         if filename not in output_node.base_path:
-            raise PublishValidationError(
+            msg = (
                 "Render output folder doesn't match the blender scene name! "
                 "Use Repair action to fix the folder file path."
             )
+            invalid.append(msg)
+        if not bpy.context.scene.render.filepath:
+            msg = (
+                "No render filepath set in the scene!"
+                "Use Repair action to fix the render filepath."
+            )
+            invalid.append(msg)
+        return invalid
 
     @classmethod
     def repair(cls, instance):
         container = instance.data["transientData"]["instance_node"]
         prepare_rendering(container)
         bpy.ops.wm.save_as_mainfile(filepath=bpy.data.filepath)
+        bpy.context.scene.render.filepath = "/tmp\\"
         cls.log.debug("Reset the render output folder...")

--- a/client/ayon_blender/plugins/publish/validate_deadline_publish.py
+++ b/client/ayon_blender/plugins/publish/validate_deadline_publish.py
@@ -82,5 +82,5 @@ class ValidateDeadlinePublish(
         container = instance.data["transientData"]["instance_node"]
         prepare_rendering(container)
         bpy.ops.wm.save_as_mainfile(filepath=bpy.data.filepath)
-        bpy.context.scene.render.filepath = "/tmp\\"
+        bpy.context.scene.render.filepath = "/tmp/"
         cls.log.debug("Reset the render output folder...")


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-blender/issues/16


## Additional info
I also refactored the validator a little bit so that it won't always error out.

## Testing notes:

1. Launch Blender
2. Create Render Instance
3. Publish
4. If validate render output for deadline errors out, make sure you perform repair action
5. Publish
6. It should be rendered successfully.
