### PR TITLE
Alembic loaders update the libpath without the removal of the cache modifier

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -191,7 +191,7 @@ def _process_app_events() -> Optional[float]:
 
         # Refresh Manager
         if GlobalClass.app:
-            manager = GlobalClass.app.get_window("WM_OT_avalon_manager")
+            manager = BlenderApplication.get_window("WM_OT_avalon_manager")
             if manager:
                 manager.refresh()
 

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -46,6 +46,8 @@ class CacheModelLoader(plugin.BlenderLoader):
                     if constraint.cache_file.name == prev_filename:
                         constraint.cache_file.name = os.path.basename(libpath)
                     constraint.cache_file.filepath = libpath.as_posix()
+                    constraint.object_path = (
+                        constraint.cache_file.object_paths[0].path)
                     found = True
                     break
             if not found:

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -43,9 +43,9 @@ class CacheModelLoader(plugin.BlenderLoader):
             found = False
             for constraint in obj.constraints:
                 if constraint.type == "TRANSFORM_CACHE":
-                    constraint.cache_file.filepath = libpath.as_posix()
                     if constraint.cache_file.name == prev_filename:
                         constraint.cache_file.name = os.path.basename(libpath)
+                    constraint.cache_file.filepath = libpath.as_posix()
                     found = True
                     break
             if not found:
@@ -55,6 +55,8 @@ class CacheModelLoader(plugin.BlenderLoader):
                 constraint = obj.constraints.new("TRANSFORM_CACHE")
                 bpy.ops.cachefile.open(filepath=libpath.as_posix())
                 constraint.cache_file = bpy.data.cache_files[-1]
+                if constraint.cache_file.name == prev_filename:
+                    constraint.cache_file.name = os.path.basename(libpath)
                 constraint.cache_file.filepath = libpath.as_posix()
                 constraint.cache_file.name = os.path.basename(libpath)
                 constraint.cache_file.scale = 1.0

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -40,28 +40,30 @@ class CacheModelLoader(plugin.BlenderLoader):
         to update the filepath of the alembic.
         """
         for obj in asset_group.children:
-            found = False
             names = [modifier.name for modifier in obj.modifiers
                      if modifier.type == "MESH_SEQUENCE_CACHE"]
+            file_list = [file for file in bpy.data.cache_files
+                         if file.name == prev_filename]
             if names:
                 for name in names:
                     obj.modifiers.remove(obj.modifiers.get(name))
+            if file_list:
+                bpy.data.batch_remove(file_list)
 
-            if not found:
-                # This is to keep compatibility with cameras loaded with
-                # the old loader
-                # Create a new constraint for the cache file
-                modifier = obj.modifiers.new(
-                    name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-                bpy.ops.cachefile.open(filepath=libpath.as_posix())
-                modifier.cache_file = bpy.data.cache_files[-1]
-                modifier.cache_file.name = os.path.basename(libpath.as_posix())
-                modifier.cache_file.filepath = libpath.as_posix()
-                modifier.cache_file.scale = 1.0
-                bpy.context.evaluated_depsgraph_get()
+            # This is to keep compatibility with cameras loaded with
+            # the old loader
+            # Create a new constraint for the cache file
+            modifier = obj.modifiers.new(
+                name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
+            bpy.ops.cachefile.open(filepath=libpath.as_posix())
+            modifier.cache_file = bpy.data.cache_files[-1]
+            modifier.cache_file.name = os.path.basename(libpath.as_posix())
+            modifier.cache_file.filepath = libpath.as_posix()
+            modifier.cache_file.scale = 1.0
+            bpy.context.evaluated_depsgraph_get()
 
-                modifier.object_path = (
-                    modifier.cache_file.object_paths[0].path)
+            modifier.object_path = (
+                modifier.cache_file.object_paths[0].path)
 
         return libpath
 

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -40,7 +40,9 @@ class CacheModelLoader(plugin.BlenderLoader):
         to update the filepath of the alembic.
         """
         bpy.ops.cachefile.open(filepath=libpath.as_posix())
-        for i, obj in enumerate(asset_group.children):
+        for obj in asset_group.children:
+            asset_name = obj.name.rsplit(":", 1)[-1]
+            print(asset_name)
             names = [modifier.name for modifier in obj.modifiers
                      if modifier.type == "MESH_SEQUENCE_CACHE"]
             file_list = [file for file in bpy.data.cache_files
@@ -59,9 +61,10 @@ class CacheModelLoader(plugin.BlenderLoader):
             modifier.cache_file.filepath = libpath.as_posix()
             modifier.cache_file.scale = 1.0
             bpy.context.evaluated_depsgraph_get()
-
-            modifier.object_path = (
-                modifier.cache_file.object_paths[i].path)
+            for object_path in modifier.cache_file.object_paths:
+                base_object_name = os.path.basename(object_path.path)
+                if base_object_name.startswith(asset_name):
+                    modifier.object_path = object_path.path
 
         return libpath
 

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -43,16 +43,13 @@ class CacheModelLoader(plugin.BlenderLoader):
             names = [modifier.name for modifier in obj.modifiers
                      if modifier.type == "MESH_SEQUENCE_CACHE"]
             file_list = [file for file in bpy.data.cache_files
-                         if file.name == prev_filename]
+                         if file.name.startswith(prev_filename)]
             if names:
                 for name in names:
                     obj.modifiers.remove(obj.modifiers.get(name))
             if file_list:
                 bpy.data.batch_remove(file_list)
 
-            # This is to keep compatibility with cameras loaded with
-            # the old loader
-            # Create a new constraint for the cache file
             modifier = obj.modifiers.new(
                 name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
             bpy.ops.cachefile.open(filepath=libpath.as_posix())

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -39,7 +39,8 @@ class CacheModelLoader(plugin.BlenderLoader):
         If there is no transform cache modifier, it will create one
         to update the filepath of the alembic.
         """
-        for obj in asset_group.children:
+        bpy.ops.cachefile.open(filepath=libpath.as_posix())
+        for i, obj in enumerate(asset_group.children):
             names = [modifier.name for modifier in obj.modifiers
                      if modifier.type == "MESH_SEQUENCE_CACHE"]
             file_list = [file for file in bpy.data.cache_files
@@ -52,15 +53,15 @@ class CacheModelLoader(plugin.BlenderLoader):
 
             modifier = obj.modifiers.new(
                 name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-            bpy.ops.cachefile.open(filepath=libpath.as_posix())
             modifier.cache_file = bpy.data.cache_files[-1]
-            modifier.cache_file.name = os.path.basename(libpath.as_posix())
+            cache_file_name = os.path.basename(libpath.as_posix())
+            modifier.cache_file.name = cache_file_name
             modifier.cache_file.filepath = libpath.as_posix()
             modifier.cache_file.scale = 1.0
             bpy.context.evaluated_depsgraph_get()
 
             modifier.object_path = (
-                modifier.cache_file.object_paths[0].path)
+                modifier.cache_file.object_paths[i].path)
 
         return libpath
 

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -34,46 +34,41 @@ class CacheModelLoader(plugin.BlenderLoader):
     icon = "code-fork"
     color = "orange"
 
-    def _update_transform_cache_path(self, asset_group, libpath, prev_filename):
+    def _update_transform_cache_path(self, asset_group, libpath):
         """search and update path in the transform cache modifier
         If there is no transform cache modifier, it will create one
         to update the filepath of the alembic.
         """
         for obj in asset_group.children:
             found = False
-            for constraint in obj.constraints:
-                if constraint.type == "TRANSFORM_CACHE":
-                    if constraint.cache_file.name == prev_filename:
-                        constraint.cache_file.name = os.path.basename(libpath)
-                    constraint.cache_file.filepath = libpath.as_posix()
-                    constraint.object_path = (
-                        constraint.cache_file.object_paths[0].path)
+            for modifier in obj.modifiers:
+                if modifier.type == "MESH_SEQUENCE_CACHE":
+                    modifier.cache_file = bpy.data.cache_files[-1]
+                    modifier.cache_file.filepath = libpath.as_posix()
+                    modifier.object_path = (
+                        modifier.cache_file.object_paths[0].path)
                     found = True
                     break
             if not found:
                 # This is to keep compatibility with cameras loaded with
                 # the old loader
                 # Create a new constraint for the cache file
-                constraint = obj.constraints.new("TRANSFORM_CACHE")
+                modifier = obj.modifiers.new(
+                    name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
                 bpy.ops.cachefile.open(filepath=libpath.as_posix())
-                constraint.cache_file = bpy.data.cache_files[-1]
-                if constraint.cache_file.name == prev_filename:
-                    constraint.cache_file.name = os.path.basename(libpath)
-                constraint.cache_file.filepath = libpath.as_posix()
-                constraint.cache_file.name = os.path.basename(libpath)
-                constraint.cache_file.scale = 1.0
+                modifier.cache_file = bpy.data.cache_files[-1]
+                modifier.cache_file.filepath = libpath.as_posix()
+                modifier.cache_file.scale = 1.0
 
                 # This is a workaround to set the object path. Blender doesn't
                 # load the list of object paths until the object is evaluated.
                 # This is a hack to force the object to be evaluated.
                 # The modifier doesn't need to be removed because camera
                 # objects don't have modifiers.
-                obj.modifiers.new(
-                    name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
                 bpy.context.evaluated_depsgraph_get()
 
-                constraint.object_path = (
-                    constraint.cache_file.object_paths[0].path)
+                modifier.object_path = (
+                    modifier.cache_file.object_paths[0].path)
 
         return libpath
 
@@ -301,9 +296,7 @@ class CacheModelLoader(plugin.BlenderLoader):
 
             asset_group.matrix_basis = mat
         else:
-            prev_filename = os.path.basename(container["libpath"])
-            libpath = self._update_transform_cache_path(
-                asset_group, libpath, prev_filename)
+            libpath = self._update_transform_cache_path(asset_group, libpath)
 
 
         metadata["libpath"] = str(libpath)

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -183,7 +183,8 @@ class AbcCameraLoader(plugin.BlenderLoader):
             self.log.info("Library already loaded, not updating...")
             return
 
-        for obj in asset_group.children:
+        bpy.ops.cachefile.open(filepath=libpath.as_posix())
+        for i, obj in enumerate(asset_group.children):
             names = [constraint.name for constraint in obj.constraints
                         if constraint.type == "TRANSFORM_CACHE"]
             file_list = [file for file in bpy.data.cache_files
@@ -195,7 +196,6 @@ class AbcCameraLoader(plugin.BlenderLoader):
                 bpy.data.batch_remove(file_list)
 
             constraint = obj.constraints.new("TRANSFORM_CACHE")
-            bpy.ops.cachefile.open(filepath=libpath.as_posix())
             constraint.cache_file = bpy.data.cache_files[-1]
             constraint.cache_file.name = os.path.basename(libpath)
             constraint.cache_file.filepath = libpath.as_posix()
@@ -203,7 +203,7 @@ class AbcCameraLoader(plugin.BlenderLoader):
             bpy.context.evaluated_depsgraph_get()
 
             constraint.object_path = (
-                constraint.cache_file.object_paths[0].path)
+                constraint.cache_file.object_paths[i].path)
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -187,8 +187,7 @@ class AbcCameraLoader(plugin.BlenderLoader):
             found = False
             for constraint in obj.constraints:
                 if constraint.type == "TRANSFORM_CACHE":
-                    if constraint.cache_file.name == prev_filename:
-                        constraint.cache_file.name = os.path.basename(libpath)
+                    constraint.cache_file = bpy.data.cache_files[-1]
                     constraint.cache_file.filepath = libpath.as_posix()
                     constraint.object_path = (
                         constraint.cache_file.object_paths[0].path)

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -190,6 +190,8 @@ class AbcCameraLoader(plugin.BlenderLoader):
                     if constraint.cache_file.name == prev_filename:
                         constraint.cache_file.name = os.path.basename(libpath)
                     constraint.cache_file.filepath = libpath.as_posix()
+                    constraint.object_path = (
+                        constraint.cache_file.object_paths[0].path)
                     found = True
                     break
             if not found:

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -184,38 +184,26 @@ class AbcCameraLoader(plugin.BlenderLoader):
             return
 
         for obj in asset_group.children:
-            found = False
-            for constraint in obj.constraints:
-                if constraint.type == "TRANSFORM_CACHE":
-                    constraint.cache_file = bpy.data.cache_files[-1]
-                    constraint.cache_file.filepath = libpath.as_posix()
-                    constraint.object_path = (
-                        constraint.cache_file.object_paths[0].path)
-                    found = True
-                    break
-            if not found:
-                # This is to keep compatibility with cameras loaded with
-                # the old loader
-                # Create a new constraint for the cache file
-                constraint = obj.constraints.new("TRANSFORM_CACHE")
-                bpy.ops.cachefile.open(filepath=libpath.as_posix())
-                constraint.cache_file = bpy.data.cache_files[-1]
-                if constraint.cache_file.name == prev_filename:
-                    constraint.cache_file.name = os.path.basename(libpath)
-                constraint.cache_file.filepath = libpath.as_posix()
-                constraint.cache_file.scale = 1.0
+            names = [constraint.name for constraint in obj.constraints
+                        if constraint.type == "TRANSFORM_CACHE"]
+            file_list = [file for file in bpy.data.cache_files
+                        if file.name.startswith(prev_filename)]
+            if names:
+                for name in names:
+                    obj.constraints.remove(obj.constraints.get(name))
+            if file_list:
+                bpy.data.batch_remove(file_list)
 
-                # This is a workaround to set the object path. Blender doesn't
-                # load the list of object paths until the object is evaluated.
-                # This is a hack to force the object to be evaluated.
-                # The modifier doesn't need to be removed because camera
-                # objects don't have modifiers.
-                obj.modifiers.new(
-                    name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-                bpy.context.evaluated_depsgraph_get()
+            constraint = obj.constraints.new("TRANSFORM_CACHE")
+            bpy.ops.cachefile.open(filepath=libpath.as_posix())
+            constraint.cache_file = bpy.data.cache_files[-1]
+            constraint.cache_file.name = os.path.basename(libpath)
+            constraint.cache_file.filepath = libpath.as_posix()
+            constraint.cache_file.scale = 1.0
+            bpy.context.evaluated_depsgraph_get()
 
-                constraint.object_path = (
-                    constraint.cache_file.object_paths[0].path)
+            constraint.object_path = (
+                constraint.cache_file.object_paths[0].path)
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from pprint import pformat
 from typing import Dict, List, Optional
 
+import os
 import bpy
 
 from ayon_core.pipeline import (
@@ -149,6 +150,7 @@ class AbcCameraLoader(plugin.BlenderLoader):
         object_name = container["objectName"]
         asset_group = bpy.data.objects.get(object_name)
         libpath = Path(get_representation_path(repre_entity))
+        prev_filename = os.path.basename(container["libpath"])
         extension = libpath.suffix.lower()
 
         self.log.info(
@@ -186,6 +188,8 @@ class AbcCameraLoader(plugin.BlenderLoader):
             for constraint in obj.constraints:
                 if constraint.type == "TRANSFORM_CACHE":
                     constraint.cache_file.filepath = libpath.as_posix()
+                    if constraint.cache_file.name == prev_filename:
+                        constraint.cache_file.name = os.path.basename(libpath)
                     found = True
                     break
             if not found:
@@ -195,6 +199,8 @@ class AbcCameraLoader(plugin.BlenderLoader):
                 constraint = obj.constraints.new("TRANSFORM_CACHE")
                 bpy.ops.cachefile.open(filepath=libpath.as_posix())
                 constraint.cache_file = bpy.data.cache_files[-1]
+                constraint.cache_file.filepath = libpath.as_posix()
+                constraint.cache_file.name = os.path.basename(libpath)
                 constraint.cache_file.scale = 1.0
 
                 # This is a workaround to set the object path. Blender doesn't

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -184,9 +184,10 @@ class AbcCameraLoader(plugin.BlenderLoader):
             return
 
         bpy.ops.cachefile.open(filepath=libpath.as_posix())
-        for i, obj in enumerate(asset_group.children):
+        for obj in asset_group.children:
+            asset_name = obj.name.rsplit(":", 1)[-1]
             names = [constraint.name for constraint in obj.constraints
-                        if constraint.type == "TRANSFORM_CACHE"]
+                     if constraint.type == "TRANSFORM_CACHE"]
             file_list = [file for file in bpy.data.cache_files
                         if file.name.startswith(prev_filename)]
             if names:
@@ -202,8 +203,10 @@ class AbcCameraLoader(plugin.BlenderLoader):
             constraint.cache_file.scale = 1.0
             bpy.context.evaluated_depsgraph_get()
 
-            constraint.object_path = (
-                constraint.cache_file.object_paths[i].path)
+            for object_path in constraint.cache_file.object_paths:
+                base_object_name = os.path.basename(object_path.path)
+                if base_object_name.startswith(asset_name):
+                    constraint.object_path = object_path.path
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -187,9 +187,9 @@ class AbcCameraLoader(plugin.BlenderLoader):
             found = False
             for constraint in obj.constraints:
                 if constraint.type == "TRANSFORM_CACHE":
-                    constraint.cache_file.filepath = libpath.as_posix()
                     if constraint.cache_file.name == prev_filename:
                         constraint.cache_file.name = os.path.basename(libpath)
+                    constraint.cache_file.filepath = libpath.as_posix()
                     found = True
                     break
             if not found:
@@ -199,8 +199,9 @@ class AbcCameraLoader(plugin.BlenderLoader):
                 constraint = obj.constraints.new("TRANSFORM_CACHE")
                 bpy.ops.cachefile.open(filepath=libpath.as_posix())
                 constraint.cache_file = bpy.data.cache_files[-1]
+                if constraint.cache_file.name == prev_filename:
+                    constraint.cache_file.name = os.path.basename(libpath)
                 constraint.cache_file.filepath = libpath.as_posix()
-                constraint.cache_file.name = os.path.basename(libpath)
                 constraint.cache_file.scale = 1.0
 
                 # This is a workaround to set the object path. Blender doesn't


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the libpath is still updated in the cache modifier without removing the modifier.


## Additional info
We need to discuss if the cache modifiers should be implemented in the load function as there is still issue updating the libpath when the users uses set version to the loaded assets for the first time.

## Testing notes:

1. Launch Blender
2. Load Pointcache/model/camera with alembic loader
3. Set version with scene inventory