### PR TITLE
Fix transforms on Empty object children not maintained by ABC cache load.

### DIFF
--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -69,24 +69,13 @@ class CacheModelLoader(plugin.BlenderLoader):
                 relative_path=relative
             )
 
-        objects = []
-        uninspected_top_objs = [obj for obj in lib.get_selection() if not obj.parent]
-
-        while uninspected_top_objs:
-            obj = uninspected_top_objs.pop()
-
-            # Ignore EMPTYs without transforms/parent (blank containers)
-            if obj.type == "EMPTY" and obj.matrix_local.is_identity:
-                uninspected_top_objs.extend(obj.children)
-                bpy.data.objects.remove(obj)
-
-            # Reparent top object to asset_group
-            else:
-                obj.parent = asset_group
-                objects.append(obj)
-                objects.extend(obj.children_recursive)
+        objects = lib.get_selection()
 
         for obj in objects:
+            # reparent top object to asset_group
+            if not obj.parent:
+                obj.parent = asset_group
+
             # Unlink the object from all collections
             collections = obj.users_collection
             for collection in collections:


### PR DESCRIPTION
## Changelog Description
Resolve #2 

These changes consolidate the way imported hierarchy is re-parented in Blender upon cache load. 
Only top nodes of "Empty" objects without any transforms will be skipped.

Published hierarchy:
![image](https://github.com/user-attachments/assets/9636c10b-da97-4d78-915d-62b7ecdbccc6)

Loaded hierarchy (note how only Empty.002 is removed cause unecessary):
![image](https://github.com/user-attachments/assets/2bf7dca6-26d3-4a98-be8c-869a2181631c)


## Additional info
This is my first MR for the project, please do let me know if any troubles.


## Testing notes:

1. Create scene with meshes 
2. Parent some of the meshes to new empty objects
3. Apply random transform on both empty and mesh objects
4. Publish the empty as a pointcacheMain
5. Load the pointcache
6. Ensure all of the transforms are preserved
