### PR TITLE
Bugfix/add tmp dir for deadline submission

### DIFF
--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -348,7 +348,7 @@ def prepare_rendering(asset_group):
     # Clear the render filepath, so that the output is handled only by the
     # output node in the compositor.
     bpy.context.scene.render.filepath = (
-        "/tmp\\"if sys.platform == "windows" else "/tmp/"
+        "/tmp\\"if sys.platform == "windows" else ""
     )
     render_settings = {
         "render_folder": render_folder,

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+import sys
 import bpy
 
 from ayon_core.settings import get_project_settings
@@ -347,8 +347,9 @@ def prepare_rendering(asset_group):
 
     # Clear the render filepath, so that the output is handled only by the
     # output node in the compositor.
-    bpy.context.scene.render.filepath = ""
-
+    bpy.context.scene.render.filepath = (
+        "/tmp\\"if sys.platform == "windows" else "/tmp/"
+    )
     render_settings = {
         "render_folder": render_folder,
         "aov_separator": aov_sep,

--- a/client/ayon_blender/plugins/publish/validate_deadline_publish.py
+++ b/client/ayon_blender/plugins/publish/validate_deadline_publish.py
@@ -82,5 +82,4 @@ class ValidateDeadlinePublish(
         container = instance.data["transientData"]["instance_node"]
         prepare_rendering(container)
         bpy.ops.wm.save_as_mainfile(filepath=bpy.data.filepath)
-        bpy.context.scene.render.filepath = "/tmp/"
         cls.log.debug("Reset the render output folder...")


### PR DESCRIPTION
## Changelog Description
Add temp directory for deadline submission so that it would not error out during deadline submission.
Continuity of https://github.com/ynput/ayon-blender/pull/17
*Support different system platform


## Additional info
n/a


## Testing notes:

1. Launch Blender
2. Create Render Instance
3. Publish
4. If validate render output for deadline errors out, make sure you perform repair action
5. Publish
6. It should be rendered successfully.
