### PR TITLE
Fix optional support for Extract USD Model

### DIFF
--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -2,11 +2,12 @@ import os
 
 import bpy
 
-from ayon_core.pipeline import KnownPublishError
+from ayon_core.pipeline import KnownPublishError, OptionalPyblishPluginMixin
 from ayon_blender.api import plugin, lib
 
 
-class ExtractUSD(plugin.BlenderExtractor):
+class ExtractUSD(plugin.BlenderExtractor,
+                 OptionalPyblishPluginMixin):
     """Extract as USD."""
 
     label = "Extract USD"
@@ -14,6 +15,8 @@ class ExtractUSD(plugin.BlenderExtractor):
     families = ["usd"]
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
 
         # Ignore runtime instances (e.g. USD layers)
         # TODO: This is better done via more specific `families`


### PR DESCRIPTION
## Changelog Description

Fix optional support for Extract USD Model

![image](https://github.com/user-attachments/assets/76ad3d6b-9fc1-4c02-8ab7-9f1d70370987)

## Additional info

It was optional by default, and had options in settings but the optional toggle was not shown nor used.

## Testing notes:

1. Optional toggle should show in publisher UI for model product type.
2. The inactive (disabled in publisher UI) state should be adhered to and do no export when toggled off.
