### PR TITLE
Add switch asset support for all loaders inheriting from `BlenderLoader`

### DIFF
--- a/client/ayon_blender/api/plugin.py
+++ b/client/ayon_blender/api/plugin.py
@@ -540,3 +540,7 @@ class BlenderLoader(LoaderPlugin):
         """ Run the remove on Blender main thread"""
         mti = MainThreadItem(self.exec_remove, container)
         execute_in_main_thread(mti)
+
+    def switch(self, container, context):
+        # Support switch in scene inventory
+        self.update(container, context)

--- a/client/ayon_blender/plugins/load/load_image_compositor.py
+++ b/client/ayon_blender/plugins/load/load_image_compositor.py
@@ -144,7 +144,3 @@ class LoadImageCompositor(plugin.BlenderLoader):
         if image and not image.users:
             self.log.debug("Removing unused image: %s", image.name)
             bpy.data.images.remove(image)
-
-    def switch(self, container, context):
-        # Support switch in scene inventory
-        self.update(container, context)


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Adds support for "Switch Asset" in scene inventory for blender loaders.


## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Based on comment [here](https://github.com/ynput/ayon-blender/pull/38#discussion_r1763243308)

## Testing notes:

1. Validate the 'switch' works as intended for managed Blender loaders
