### PR TITLE
Fix frame range attributes for instances + validations

### DIFF
--- a/client/ayon_blender/api/colorspace.py
+++ b/client/ayon_blender/api/colorspace.py
@@ -22,18 +22,20 @@ class RenderProduct(object):
 
 
 class ARenderProduct(object):
-    def __init__(self):
+    def __init__(self, frame_start, frame_end):
         """Constructor."""
         # Initialize
-        self.layer_data = self._get_layer_data()
+        self.layer_data = self._get_layer_data(frame_start, frame_end)
         self.layer_data.products = self.get_render_products()
 
-    def _get_layer_data(self):
-        scene = bpy.context.scene
-
+    def _get_layer_data(
+        self,
+        frame_start: int,
+        frame_end: int
+    ) -> LayerMetadata:
         return LayerMetadata(
-            frameStart=int(scene.frame_start),
-            frameEnd=int(scene.frame_end),
+            frameStart=int(frame_start),
+            frameEnd=int(frame_end),
         )
 
     def get_render_products(self):

--- a/client/ayon_blender/api/colorspace.py
+++ b/client/ayon_blender/api/colorspace.py
@@ -1,7 +1,5 @@
 import attr
 
-import bpy
-
 
 @attr.s
 class LayerMetadata(object):

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -2,7 +2,7 @@ import os
 import traceback
 import importlib
 import contextlib
-from typing import Dict, List, Union
+from typing import Dict, List, Union, TYPE_CHECKING
 
 import bpy
 import addon_utils
@@ -10,7 +10,9 @@ from ayon_core.lib import (
     Logger,
     NumberDef
 )
-from ayon_core.pipeline.create import CreateContext
+
+if TYPE_CHECKING:
+    from ayon_core.pipeline.create import CreateContext
 
 from . import pipeline
 

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -12,7 +12,7 @@ from ayon_core.lib import (
 )
 
 if TYPE_CHECKING:
-    from ayon_core.pipeline.create import CreateContext
+    from ayon_core.pipeline.create import CreateContext  # noqa: E401
 
 from . import pipeline
 

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -12,7 +12,7 @@ from ayon_core.lib import (
 )
 
 if TYPE_CHECKING:
-    from ayon_core.pipeline.create import CreateContext  # noqa: E401
+    from ayon_core.pipeline.create import CreateContext  # noqa: F401
 
 from . import pipeline
 

--- a/client/ayon_blender/plugins/create/create_animation.py
+++ b/client/ayon_blender/plugins/create/create_animation.py
@@ -32,5 +32,6 @@ class CreateAnimation(plugin.BlenderCreator):
         return collection
 
     def get_instance_attr_defs(self):
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(self.create_context,
+                                          step=False)
         return defs

--- a/client/ayon_blender/plugins/create/create_camera.py
+++ b/client/ayon_blender/plugins/create/create_camera.py
@@ -42,5 +42,5 @@ class CreateCamera(plugin.BlenderCreator):
         return asset_group
 
     def get_instance_attr_defs(self):
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(self.create_context)
         return defs

--- a/client/ayon_blender/plugins/create/create_pointcache.py
+++ b/client/ayon_blender/plugins/create/create_pointcache.py
@@ -29,6 +29,7 @@ class CreatePointcache(plugin.BlenderCreator):
         return collection
 
     def get_instance_attr_defs(self):
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(self.create_context,
+                                          step=False)
 
         return defs

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -49,6 +49,6 @@ class CreateRenderlayer(plugin.BlenderCreator):
         return collection
 
     def get_instance_attr_defs(self):
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(self.create_context)
 
         return defs

--- a/client/ayon_blender/plugins/create/create_review.py
+++ b/client/ayon_blender/plugins/create/create_review.py
@@ -27,6 +27,6 @@ class CreateReview(plugin.BlenderCreator):
         return collection
 
     def get_instance_attr_defs(self):
-        defs = lib.collect_animation_defs()
+        defs = lib.collect_animation_defs(self.create_context)
 
         return defs

--- a/client/ayon_blender/plugins/publish/collect_instance_frame_range.py
+++ b/client/ayon_blender/plugins/publish/collect_instance_frame_range.py
@@ -1,0 +1,31 @@
+import pyblish.api
+from ayon_blender.api import plugin
+
+
+class CollectFrameRangeFromCreator(plugin.BlenderInstancePlugin):
+
+    order = pyblish.api.CollectorOrder - 0.4
+    hosts = ["blender"]
+    families = ["*"]
+    label = "Collect Frame Range from creator"
+
+    def process(self, instance):
+        creator_attributes: dict = instance.data.get("creator_attributes", {})
+        frame_keys = [
+            "frameStart",
+            "frameEnd",
+            "handleStart",
+            "handleEnd"
+        ]
+        for key in frame_keys:
+            if key in creator_attributes:
+                instance.data[key] = creator_attributes[key]
+
+        if all(key in instance.data for key in frame_keys):
+            # Calculate frameStartHandle and frameEndHandle
+            instance.data["frameStartHandle"] = (
+                instance.data["frameStart"] - instance.data["handleStart"]
+            )
+            instance.data["frameEndHandle"] = (
+                instance.data["frameEnd"] - instance.data["handleEnd"]
+            )

--- a/client/ayon_blender/plugins/publish/collect_render.py
+++ b/client/ayon_blender/plugins/publish/collect_render.py
@@ -110,5 +110,8 @@ class CollectBlenderRender(plugin.BlenderInstancePlugin):
             "colorspaceConfig": "",
             "colorspaceDisplay": "sRGB",
             "colorspaceView": "ACES 1.0 SDR-video",
-            "renderProducts": colorspace.ARenderProduct(),
+            "renderProducts": colorspace.ARenderProduct(
+                frame_start=frame_start,
+                frame_end=frame_end
+            ),
         })

--- a/client/ayon_blender/plugins/publish/collect_render.py
+++ b/client/ayon_blender/plugins/publish/collect_render.py
@@ -83,10 +83,8 @@ class CollectBlenderRender(plugin.BlenderInstancePlugin):
         ext = render_data.get("image_format")
         multilayer = render_data.get("multilayer_exr")
 
-        frame_start = context.data["frameStart"]
-        frame_end = context.data["frameEnd"]
-        frame_handle_start = context.data["frameStartHandle"]
-        frame_handle_end = context.data["frameEndHandle"]
+        frame_start = instance.data["frameStartHandle"]
+        frame_end = instance.data["frameEndHandle"]
 
         expected_beauty = self.generate_expected_beauty(
             render_product, int(frame_start), int(frame_end),
@@ -100,10 +98,6 @@ class CollectBlenderRender(plugin.BlenderInstancePlugin):
 
         instance.data.update({
             "families": ["render", "render.farm"],
-            "frameStart": frame_start,
-            "frameEnd": frame_end,
-            "frameStartHandle": frame_handle_start,
-            "frameEndHandle": frame_handle_end,
             "fps": context.data["fps"],
             "byFrameStep": bpy.context.scene.frame_step,
             "review": render_data.get("review", False),

--- a/client/ayon_blender/plugins/publish/collect_render.py
+++ b/client/ayon_blender/plugins/publish/collect_render.py
@@ -99,7 +99,7 @@ class CollectBlenderRender(plugin.BlenderInstancePlugin):
         instance.data.update({
             "families": ["render", "render.farm"],
             "fps": context.data["fps"],
-            "byFrameStep": bpy.context.scene.frame_step,
+            "byFrameStep": instance.data["creator_attributes"].get("step", 1),
             "review": render_data.get("review", False),
             "multipartExr": ext == "exr" and multilayer,
             "farm": True,

--- a/client/ayon_blender/plugins/publish/collect_review.py
+++ b/client/ayon_blender/plugins/publish/collect_review.py
@@ -48,8 +48,6 @@ class CollectReview(plugin.BlenderInstancePlugin):
 
             instance.data.update({
                 "review_camera": camera,
-                "frameStart": instance.context.data["frameStart"],
-                "frameEnd": instance.context.data["frameEnd"],
                 "fps": instance.context.data["fps"],
                 "isolate": isolate_objects,
             })

--- a/client/ayon_blender/plugins/publish/extract_abc_animation.py
+++ b/client/ayon_blender/plugins/publish/extract_abc_animation.py
@@ -3,7 +3,7 @@ import os
 import bpy
 
 from ayon_core.pipeline import publish
-from ayon_blender.api import plugin, lib
+from ayon_blender.api import plugin
 
 
 class ExtractAnimationABC(
@@ -54,26 +54,15 @@ class ExtractAnimationABC(
 
         context = plugin.create_blender_context(
             active=asset_group, selected=selected)
-
-        scene_overrides = {
-            "frame_start": instance.data.get("frameStart"),
-            "frame_end": instance.data.get("frameEnd"),
-            "frame_step": instance.data.get("frameStep"),
-        }
-        # Skip None value overrides
-        scene_overrides = {
-            key: value for key, value in scene_overrides.items()
-            if value is not None
-        }
-
-        with lib.attribute_overrides(bpy.context.scene, scene_overrides):
-            with bpy.context.temp_override(**context):
-                # We export the abc
-                bpy.ops.wm.alembic_export(
-                    filepath=filepath,
-                    selected=True,
-                    flatten=False
-                )
+        with bpy.context.temp_override(**context):
+            # We export the abc
+            bpy.ops.wm.alembic_export(
+                filepath=filepath,
+                selected=True,
+                flatten=False,
+                start=instance.data["frameStartHandle"],
+                end=instance.data["frameEndHandle"]
+            )
 
         plugin.deselect_all()
 

--- a/client/ayon_blender/plugins/publish/extract_camera_abc.py
+++ b/client/ayon_blender/plugins/publish/extract_camera_abc.py
@@ -46,9 +46,6 @@ class ExtractCameraABC(
             active=active, selected=selected)
 
         scene_overrides = {
-            "frame_start": instance.data.get("frameStart"),
-            "frame_end": instance.data.get("frameEnd"),
-            "frame_step": instance.data.get("frameStep"),
             "unit_settings.scale_length": instance.data.get("unitScale"),
         }
         # Skip None value overrides
@@ -56,8 +53,6 @@ class ExtractCameraABC(
             key: value for key, value in scene_overrides.items()
             if value is not None
         }
-        if "render.fps" in scene_overrides:
-            scene_overrides["render.fps_base"] = 1
 
         with lib.attribute_overrides(bpy.context.scene, scene_overrides):
             with bpy.context.temp_override(**context):
@@ -65,7 +60,9 @@ class ExtractCameraABC(
                 bpy.ops.wm.alembic_export(
                     filepath=filepath,
                     selected=True,
-                    flatten=True
+                    flatten=True,
+                    start=instance.data["frameStartHandle"],
+                    end=instance.data["frameEndHandle"]
                 )
 
         plugin.deselect_all()

--- a/client/ayon_blender/plugins/publish/validate_frame_range.py
+++ b/client/ayon_blender/plugins/publish/validate_frame_range.py
@@ -92,19 +92,13 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
     def repair(cls, instance):
         frame_range = cls.get_expected_frame_range(instance)
 
-        if instance.data["productType"] == "render":
-            # Render uses scene frame range
-            bpy.context.scene.frame_start = frame_range["frameStart"]
-            bpy.context.scene.frame_end = frame_range["frameEnd"]
+        # Update the frame range attributes on the instance
+        create_context = instance.context.data["create_context"]
+        create_instance = create_context.get_instance_by_id(
+            instance.data["instance_id"]
+        )
 
-        else:
-            # Update the frame range attributes on the instance
-            create_context = instance.context.data["create_context"]
-            create_instance = create_context.get_instance_by_id(
-                instance.data["instance_id"]
-            )
-
-            creator_attributes = create_instance["creator_attributes"]
-            creator_attributes["frameStart"] = frame_range["frameStart"]
-            creator_attributes["frameEnd"] = frame_range["frameEnd"]
-            create_context.save_changes()
+        creator_attributes = create_instance["creator_attributes"]
+        creator_attributes["frameStart"] = frame_range["frameStart"]
+        creator_attributes["frameEnd"] = frame_range["frameEnd"]
+        create_context.save_changes()

--- a/client/ayon_blender/plugins/publish/validate_frame_range.py
+++ b/client/ayon_blender/plugins/publish/validate_frame_range.py
@@ -1,5 +1,4 @@
 from typing import Dict
-import bpy
 import pyblish.api
 
 from ayon_core.pipeline import (

--- a/client/ayon_blender/plugins/publish/validate_frame_range.py
+++ b/client/ayon_blender/plugins/publish/validate_frame_range.py
@@ -42,14 +42,8 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
             return
 
         frame_range = self.get_expected_frame_range(instance)
-        scene = bpy.context.scene
-
-        if instance.data["productType"] == "render":
-            inst_frame_start = scene.frame_start
-            inst_frame_end = scene.frame_end
-        else:
-            inst_frame_start = instance.data["frameStart"]
-            inst_frame_end = instance.data["frameEnd"]
+        inst_frame_start = instance.data["frameStart"]
+        inst_frame_end = instance.data["frameEnd"]
 
         if inst_frame_start is None or inst_frame_end is None:
             raise KnownPublishError(

--- a/client/ayon_blender/plugins/publish/validate_frame_range.py
+++ b/client/ayon_blender/plugins/publish/validate_frame_range.py
@@ -1,3 +1,4 @@
+from typing import Dict
 import bpy
 import pyblish.api
 
@@ -30,7 +31,7 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
 
     label = "Validate Frame Range"
     order = ValidateContentsOrder
-    families = ["render"]
+    families = ["animation", "camera", "pointcache", "render", "review"]
     hosts = ["blender"]
     optional = True
     actions = [RepairAction]
@@ -40,10 +41,15 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
             self.log.debug("Skipping Validate Frame Range...")
             return
 
-        frame_range = get_frame_range(instance.data["taskEntity"])
+        frame_range = self.get_expected_frame_range(instance)
         scene = bpy.context.scene
-        inst_frame_start = scene.frame_start
-        inst_frame_end = scene.frame_end
+
+        if instance.data["productType"] == "render":
+            inst_frame_start = scene.frame_start
+            inst_frame_end = scene.frame_end
+        else:
+            inst_frame_start = instance.data["frameStart"]
+            inst_frame_end = instance.data["frameEnd"]
 
         if inst_frame_start is None or inst_frame_end is None:
             raise KnownPublishError(
@@ -55,13 +61,14 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
         errors = []
         if frame_start != inst_frame_start:
             errors.append(
-                f"Start frame ({inst_frame_start}) on instance does not match " # noqa
-                f"with the start frame ({frame_start}) set on the folder attributes. ")    # noqa
+                f"Start frame ({inst_frame_start}) on instance does not match "
+                f"with the start frame ({frame_start}) set on the task "
+                "attributes.")
         if frame_end != inst_frame_end:
             errors.append(
                 f"End frame ({inst_frame_end}) on instance does not match "
                 f"with the end frame ({frame_end}) "
-                "from the folder attributes. ")
+                "from the task attributes.")
 
         if errors:
             bullet_point_errors = "\n".join(
@@ -75,7 +82,35 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
             raise PublishValidationError(report, title="Frame Range incorrect")
 
     @classmethod
+    def get_expected_frame_range(
+        cls, instance: pyblish.api.Instance
+    ) -> Dict[str, int]:
+        """Get required frame range"""
+        entity = instance.data["taskEntity"]
+
+        # Task is not required for a publish instance, so we may need to
+        # validate against the folder entity
+        if not entity:
+            entity = instance.data["folderEntity"]
+        return get_frame_range(entity)
+
+    @classmethod
     def repair(cls, instance):
-        frame_range = get_frame_range(instance.data["taskEntity"])
-        bpy.context.scene.frame_start = frame_range["frameStart"]
-        bpy.context.scene.frame_end = frame_range["frameEnd"]
+        frame_range = cls.get_expected_frame_range(instance)
+
+        if instance.data["productType"] == "render":
+            # Render uses scene frame range
+            bpy.context.scene.frame_start = frame_range["frameStart"]
+            bpy.context.scene.frame_end = frame_range["frameEnd"]
+
+        else:
+            # Update the frame range attributes on the instance
+            create_context = instance.context.data["create_context"]
+            create_instance = create_context.get_instance_by_id(
+                instance.data["instance_id"]
+            )
+
+            creator_attributes = create_instance["creator_attributes"]
+            creator_attributes["frameStart"] = frame_range["frameStart"]
+            creator_attributes["frameEnd"] = frame_range["frameEnd"]
+            create_context.save_changes()


### PR DESCRIPTION
## Changelog Description

- Discard 'step' for pointcache/animation since it did not influence the output alembic at all.
- Default the frame range to current context task entity instead of current scene
- Add handle start and handle end attributes to be explicit about that, defaulting to current task attribs.
- Actually fix passing along the start and end frame to the Alembic export from creator to instance data.
- Add support for validating frame range against the instance's task/folder entity for review, pointcache, animation, etc. + support repair method for those.
- Remove redundant 'scene overrides' that tried to use that to affect what the alembic export did - but it didn't do much, and the export command has dedicated arguments for that.

## Additional info

I have no idea whether the `step` attribute does work for the other export methods, e.g. FBX or alike but we may need to double check that to see whether the `step` attribute is relevant anywhere.

Sorry for the big changes, but this really was way easier to fix when combining them.

## Testing notes:

The following product types should adhere to the frame ranges specified on the instances, be validated against the frame range (optionally) and when invalidated should allow repair to work.
1. [x] animation
2. [x] camera
3. [x] pointcache
4. [ ] render
5. [x] review