### PR TITLE
Make sure there is object path filled into the cache modifier

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -566,28 +566,14 @@ def collect_animation_defs(create_context, step=True, fps=False):
 
 def get_cache_modifiers(obj, modifier_type="MESH_SEQUENCE_CACHE"):
     modifiers_dict = {}
-    modifiers = []
-    modifier_names = [modifier.name for modifier in obj.modifiers
-                      if modifier.type == modifier_type]
-    if modifier_names:
-        modifiers = [modifier for modifier in obj.modifiers
-                     if modifier.type == modifier_type]
-        modifiers_dict = {
-            obj.name: (
-                modifier for modifier in obj.modifiers
-                if modifier.type == modifier_type
-            )
-        }
+    modifiers = [modifier for modifier in obj.modifiers
+                 if modifier.type == modifier_type]
+    if modifiers:
+        modifiers_dict[obj.name] = modifiers
     else:
         for sub_obj in obj.children:
             for ob in sub_obj.children:
                 cache_modifiers = [modifier for modifier in ob.modifiers
                                    if modifier.type == modifier_type]
-                modifiers.extend(cache_modifiers)
-                modifiers_dict.update({
-                    ob.name: (
-                        modifier for modifier in ob.modifiers
-                        if modifier.type == modifier_type
-                    )
-                })
+                modifiers_dict[ob.name] = cache_modifiers
     return modifiers_dict

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -524,3 +524,18 @@ def collect_animation_defs(fps=False):
         defs.append(fps_def)
 
     return defs
+
+
+def get_cache_modifiers(obj, modifier_type="MESH_SEQUENCE_CACHE"):
+    modifiers = []
+    modifier_names = [modifier.name for modifier in obj.modifiers
+                      if modifier.type == modifier_type]
+    if modifier_names:
+        modifiers = [modifier for modifier in obj.modifiers
+                     if modifier.type == modifier_type]
+    else:
+        for sub_obj in obj.children:
+            for ob in sub_obj.children:
+                modifiers = [modifier.name for modifier in ob.modifiers
+                            if modifier.type == modifier_type]
+    return modifiers

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -565,15 +565,29 @@ def collect_animation_defs(create_context, step=True, fps=False):
 
 
 def get_cache_modifiers(obj, modifier_type="MESH_SEQUENCE_CACHE"):
+    modifiers_dict = {}
     modifiers = []
     modifier_names = [modifier.name for modifier in obj.modifiers
                       if modifier.type == modifier_type]
     if modifier_names:
         modifiers = [modifier for modifier in obj.modifiers
                      if modifier.type == modifier_type]
+        modifiers_dict = {
+            obj.name: (
+                modifier for modifier in obj.modifiers
+                if modifier.type == modifier_type
+            )
+        }
     else:
         for sub_obj in obj.children:
             for ob in sub_obj.children:
-                modifiers = [modifier for modifier in ob.modifiers
-                             if modifier.type == modifier_type]
-    return modifiers
+                cache_modifiers = [modifier for modifier in ob.modifiers
+                                   if modifier.type == modifier_type]
+                modifiers.extend(cache_modifiers)
+                modifiers_dict.update({
+                    ob.name: (
+                        modifier for modifier in ob.modifiers
+                        if modifier.type == modifier_type
+                    )
+                })
+    return modifiers_dict

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -536,6 +536,6 @@ def get_cache_modifiers(obj, modifier_type="MESH_SEQUENCE_CACHE"):
     else:
         for sub_obj in obj.children:
             for ob in sub_obj.children:
-                modifiers = [modifier.name for modifier in ob.modifiers
-                            if modifier.type == modifier_type]
+                modifiers = [modifier for modifier in ob.modifiers
+                             if modifier.type == modifier_type]
     return modifiers

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -54,20 +54,20 @@ class CacheModelLoader(plugin.BlenderLoader):
 
             modifier = obj.modifiers.new(
                 name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-            for modifier in obj.modifiers:
-                if modifier.type == "MESH_SEQUENCE_CACHE":
-                    modifier.cache_file = bpy.data.cache_files[-1]
-                    cache_file_name = os.path.basename(libpath.as_posix())
-                    modifier.cache_file.name = cache_file_name
-                    modifier.cache_file.filepath = libpath.as_posix()
-                    modifier.cache_file.scale = 1.0
-                    bpy.context.evaluated_depsgraph_get()
-                    for object_path in modifier.cache_file.object_paths:
-                        base_object_name = os.path.basename(object_path.path)
-                        if base_object_name.startswith(asset_name):
-                            modifier.object_path = object_path.path
-                    if not modifier.object_path:
-                        modifier.object_path = modifier.cache_file.object_paths[-1].path
+            if modifier is None:
+                continue
+            modifier.cache_file = bpy.data.cache_files[-1]
+            cache_file_name = os.path.basename(libpath.as_posix())
+            modifier.cache_file.name = cache_file_name
+            modifier.cache_file.filepath = libpath.as_posix()
+            modifier.cache_file.scale = 1.0
+            bpy.context.evaluated_depsgraph_get()
+            for object_path in modifier.cache_file.object_paths:
+                base_object_name = os.path.basename(object_path.path)
+                if base_object_name.startswith(asset_name):
+                    modifier.object_path = object_path.path
+            if not modifier.object_path:
+                modifier.object_path = modifier.cache_file.object_paths[-1].path
         return libpath
 
     def _remove(self, asset_group):

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -42,7 +42,6 @@ class CacheModelLoader(plugin.BlenderLoader):
         bpy.ops.cachefile.open(filepath=libpath.as_posix())
         for obj in asset_group.children:
             asset_name = obj.name.rsplit(":", 1)[-1]
-            print(asset_name)
             names = [modifier.name for modifier in obj.modifiers
                      if modifier.type == "MESH_SEQUENCE_CACHE"]
             file_list = [file for file in bpy.data.cache_files
@@ -55,17 +54,19 @@ class CacheModelLoader(plugin.BlenderLoader):
 
             modifier = obj.modifiers.new(
                 name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-            modifier.cache_file = bpy.data.cache_files[-1]
-            cache_file_name = os.path.basename(libpath.as_posix())
-            modifier.cache_file.name = cache_file_name
-            modifier.cache_file.filepath = libpath.as_posix()
-            modifier.cache_file.scale = 1.0
-            bpy.context.evaluated_depsgraph_get()
-            for object_path in modifier.cache_file.object_paths:
-                base_object_name = os.path.basename(object_path.path)
-                if base_object_name.startswith(asset_name):
-                    modifier.object_path = object_path.path
-
+            if bpy.data.cache_files:
+                modifier.cache_file = bpy.data.cache_files[-1]
+                cache_file_name = os.path.basename(libpath.as_posix())
+                modifier.cache_file.name = cache_file_name
+                modifier.cache_file.filepath = libpath.as_posix()
+                modifier.cache_file.scale = 1.0
+                bpy.context.evaluated_depsgraph_get()
+                for object_path in modifier.cache_file.object_paths:
+                    base_object_name = os.path.basename(object_path.path)
+                    if base_object_name.startswith(asset_name):
+                        modifier.object_path = object_path.path
+                if not modifier.object_path:
+                    modifier.object_path = modifier.cache_file.object_paths[-1].path
         return libpath
 
     def _remove(self, asset_group):

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -55,20 +55,20 @@ class CacheModelLoader(plugin.BlenderLoader):
             obj.modifiers.new(name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
 
             modifiers = lib.get_cache_modifiers(obj)
-            for modifier in modifiers:
-                if modifier.type == "MESH_SEQUENCE_CACHE":
-                    modifier.cache_file = bpy.data.cache_files[-1]
-                    cache_file_name = os.path.basename(libpath.as_posix())
-                    modifier.cache_file.name = cache_file_name
-                    modifier.cache_file.filepath = libpath.as_posix()
-                    modifier.cache_file.scale = 1.0
-                    bpy.context.evaluated_depsgraph_get()
-                    for object_path in modifier.cache_file.object_paths:
-                        base_object_name = os.path.basename(object_path.path)
-                        if base_object_name.startswith(asset_name):
-                            modifier.object_path = object_path.path
-                    if not modifier.object_path:
-                        modifier.object_path = modifier.cache_file.object_paths[-1].path
+            for asset_name, modifier_list in modifiers.items():
+                for modifier in modifier_list:
+                    if modifier.type == "MESH_SEQUENCE_CACHE":
+                        modifier.cache_file = bpy.data.cache_files[-1]
+                        cache_file_name = os.path.basename(libpath.as_posix())
+                        modifier.cache_file.name = cache_file_name
+                        modifier.cache_file.filepath = libpath.as_posix()
+                        modifier.cache_file.scale = 1.0
+                        for object_path in modifier.cache_file.object_paths:
+                            base_object_name = os.path.basename(object_path.path)
+                            asset_name = asset_name.rsplit(":", 1)[-1]
+                            if base_object_name.endswith(asset_name):
+                                modifier.object_path = object_path.path
+                        bpy.context.evaluated_depsgraph_get()
 
         return libpath
 

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -54,19 +54,20 @@ class CacheModelLoader(plugin.BlenderLoader):
 
             modifier = obj.modifiers.new(
                 name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-            if modifier is not None:
-                modifier.cache_file = bpy.data.cache_files[-1]
-                cache_file_name = os.path.basename(libpath.as_posix())
-                modifier.cache_file.name = cache_file_name
-                modifier.cache_file.filepath = libpath.as_posix()
-                modifier.cache_file.scale = 1.0
-                bpy.context.evaluated_depsgraph_get()
-                for object_path in modifier.cache_file.object_paths:
-                    base_object_name = os.path.basename(object_path.path)
-                    if base_object_name.startswith(asset_name):
-                        modifier.object_path = object_path.path
-                if not modifier.object_path:
-                    modifier.object_path = modifier.cache_file.object_paths[-1].path
+            for modifier in obj.modifiers:
+                if modifier.type == "MESH_SEQUENCE_CACHE":
+                    modifier.cache_file = bpy.data.cache_files[-1]
+                    cache_file_name = os.path.basename(libpath.as_posix())
+                    modifier.cache_file.name = cache_file_name
+                    modifier.cache_file.filepath = libpath.as_posix()
+                    modifier.cache_file.scale = 1.0
+                    bpy.context.evaluated_depsgraph_get()
+                    for object_path in modifier.cache_file.object_paths:
+                        base_object_name = os.path.basename(object_path.path)
+                        if base_object_name.startswith(asset_name):
+                            modifier.object_path = object_path.path
+                    if not modifier.object_path:
+                        modifier.object_path = modifier.cache_file.object_paths[-1].path
         return libpath
 
     def _remove(self, asset_group):

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -54,7 +54,7 @@ class CacheModelLoader(plugin.BlenderLoader):
 
             modifier = obj.modifiers.new(
                 name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-            if bpy.data.cache_files:
+            if modifier is not None:
                 modifier.cache_file = bpy.data.cache_files[-1]
                 cache_file_name = os.path.basename(libpath.as_posix())
                 modifier.cache_file.name = cache_file_name

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -52,22 +52,24 @@ class CacheModelLoader(plugin.BlenderLoader):
             if file_list:
                 bpy.data.batch_remove(file_list)
 
-            modifier = obj.modifiers.new(
-                name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
-            if modifier is None:
-                continue
-            modifier.cache_file = bpy.data.cache_files[-1]
-            cache_file_name = os.path.basename(libpath.as_posix())
-            modifier.cache_file.name = cache_file_name
-            modifier.cache_file.filepath = libpath.as_posix()
-            modifier.cache_file.scale = 1.0
-            bpy.context.evaluated_depsgraph_get()
-            for object_path in modifier.cache_file.object_paths:
-                base_object_name = os.path.basename(object_path.path)
-                if base_object_name.startswith(asset_name):
-                    modifier.object_path = object_path.path
-            if not modifier.object_path:
-                modifier.object_path = modifier.cache_file.object_paths[-1].path
+            obj.modifiers.new(name='MeshSequenceCache', type='MESH_SEQUENCE_CACHE')
+
+            modifiers = lib.get_cache_modifiers(obj)
+            for modifier in modifiers:
+                if modifier.type == "MESH_SEQUENCE_CACHE":
+                    modifier.cache_file = bpy.data.cache_files[-1]
+                    cache_file_name = os.path.basename(libpath.as_posix())
+                    modifier.cache_file.name = cache_file_name
+                    modifier.cache_file.filepath = libpath.as_posix()
+                    modifier.cache_file.scale = 1.0
+                    bpy.context.evaluated_depsgraph_get()
+                    for object_path in modifier.cache_file.object_paths:
+                        base_object_name = os.path.basename(object_path.path)
+                        if base_object_name.startswith(asset_name):
+                            modifier.object_path = object_path.path
+                    if not modifier.object_path:
+                        modifier.object_path = modifier.cache_file.object_paths[-1].path
+
         return libpath
 
     def _remove(self, asset_group):


### PR DESCRIPTION
## Changelog Description
This PR is the quick fix on the object path not being filled into the mesh sequence modifier.


## Additional info
n/a

## Testing notes:

1. Launch Blender
2. Load PointCache, Model and Animation
3. Update/Setting Version to the geometry
4. Repeat 3
5. Object path of the modifier should be filled.
