### PR TITLE
Fix managing of loaded compositor image nodes

### DIFF
--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -616,8 +616,13 @@ def ls() -> Iterator:
     disk, it lists assets already loaded in Blender; once loaded they are
     called containers.
     """
+    container_ids = {
+        AYON_CONTAINER_ID,
+        # Backwards compatibility
+        AVALON_CONTAINER_ID
+    }
 
-    for id_type in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}:
+    for id_type in container_ids:
         for container in lib.lsattr("id", id_type):
             yield parse_container(container)
 
@@ -628,7 +633,7 @@ def ls() -> Iterator:
             if not node.get(AVALON_PROPERTY):
                 continue
 
-            if node.get(AVALON_PROPERTY).get("id") != id_type:
+            if node.get(AVALON_PROPERTY).get("id") not in container_ids:
                 continue
 
             yield parse_container(node)


### PR DESCRIPTION
## Changelog Description

Correctly parse compositor node containers using both new and old container id key

## Additional info

Reported on Discord [here](https://discord.com/channels/517362899170230292/563751989075378201/1297855852866437152)

## Testing notes:

1. Load image to compositor
2. Check scene inventory (AYON > Manage...) it should list the loaded container.