### PR TITLE
Refactor render workflow to manage render compositor network outputs instead of forced render structure

### DIFF
--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -1,15 +1,15 @@
 """Create render."""
 import bpy
 
-from ayon_core.lib import version_up
-from ayon_core.pipeline.context_tools import version_up_current_workfile
+from ayon_core.pipeline import AYON_CONTAINER_ID
+from ayon_core.pipeline.create import CreatedInstance
+
 from ayon_blender.api import plugin, lib
 from ayon_blender.api.render_lib import prepare_rendering
-from ayon_blender.api.workio import save_file
 
 
 class CreateRenderlayer(plugin.BlenderCreator):
-    """Single baked camera."""
+    """Create render instance."""
 
     identifier = "io.openpype.creators.blender.render"
     label = "Render"
@@ -19,6 +19,13 @@ class CreateRenderlayer(plugin.BlenderCreator):
     def create(
         self, product_name: str, instance_data: dict, pre_create_data: dict
     ):
+        # TODO: Create compositor node and imprint there.
+        # Create a compositor `CompositorNodeOutputFile` node as instance node
+        # And pre-connect any existing passes according to settings.
+        # It's important this does not mess up other existing networks in the
+        # compositing node tree, so that it remains non-destructive.
+        # TODO: Do not override scene render engine (unless explicitly enabled)
+
         try:
             # Run parent create method
             collection = super().create(
@@ -31,24 +38,60 @@ class CreateRenderlayer(plugin.BlenderCreator):
             bpy.data.collections.remove(collection)
             raise
 
-        # TODO: this is undesiderable, but it's the only way to be sure that
-        # the file is saved before the render starts.
-        # Blender, by design, doesn't set the file as dirty if modifications
-        # happen by script. So, when creating the instance and setting the
-        # render settings, the file is not marked as dirty. This means that
-        # there is the risk of sending to deadline a file without the right
-        # settings. Even the validator to check that the file is saved will
-        # detect the file as saved, even if it isn't. The only solution for
-        # now it is to force the file to be saved.
-        if not bpy.data.filepath:
-            version_up_current_workfile()
-        else:
-            filepath = version_up(bpy.data.filepath)
-            save_file(filepath, copy=False)
-
         return collection
+
+    def collect_instances(self):
+
+        # Collect regularly
+        super().collect_instances()
+
+        # TODO: Convert legacy instances so that they are imprinted on the
+        #  output node instead.
+        # TODO: Maybe do not auto-collect any compositor node output file
+
+        # Also collect any render output file nodes that are not 'registered'
+        # yet
+        if not bpy.context.scene.use_nodes:
+            return
+
+        tree = bpy.context.scene.node_tree
+        for node in tree.nodes:
+            if node.bl_idname != "CompositorNodeOutputFile":
+                continue
+
+            # If not is already imprinted and hence 'registered' we skip
+            # it to avoid registering twice.
+            project_name = self.create_context.get_current_project_name()
+            folder_entity = self.create_context.get_current_folder_entity()
+            task_entity = self.create_context.get_current_task_entity()
+            task_name = self.create_context.get_current_task_name()
+            host_name = "blender"
+            variant = node.name
+            product_name = self.get_product_name(
+                project_name,
+                folder_entity,
+                task_entity,
+                variant,
+                host_name,
+                project_entity=self.create_context.get_current_project_entity()
+            )
+            data = {
+                "folderPath": folder_entity["path"],
+                "task": task_name,
+                "variant": variant,
+                "productName": product_name,
+                "productType": self.product_type,
+                "creator_identifier": self.identifier,
+                "id": AYON_CONTAINER_ID
+            }
+            instance = CreatedInstance(
+                self.product_type, product_name, data, self
+            )
+            instance.transient_data["instance_node"] = node
+
+            # Add instance to create context
+            self._add_instance_to_context(instance)
 
     def get_instance_attr_defs(self):
         defs = lib.collect_animation_defs(self.create_context)
-
         return defs

--- a/client/ayon_blender/plugins/publish/collect_render.py
+++ b/client/ayon_blender/plugins/publish/collect_render.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-"""Collect render data."""
-
 import os
 import re
 
@@ -11,7 +8,25 @@ from ayon_blender.api import colorspace, plugin
 
 
 class CollectBlenderRender(plugin.BlenderInstancePlugin):
-    """Gather all publishable render instances."""
+    """Gather all publishable render instances.
+
+    For the instance node (bpy.types.CompositorNodeOutputFile) we collect the
+    configured output paths (FileSlots or LayerSlots) and their colorspaces.
+
+    ### AOV identifiers
+
+    When multiple outputs are present (only the case when not rendering to
+    multilayer EXR) then we assign each output an 'aov identifier' that will
+    be added to the product name. So that product: `renderLightingMain` becomes
+    for example `renderLightingMain.beauty` and `renderLightingMain.diffuse`.
+
+    ### Requires enabled compositing node tree
+
+    The render workflow requires Blender to be configured to use the
+    Compositor Node Tree, because it relies on `CompositorNodeOutputFile` to
+    define the output files for rendering.
+
+    """
 
     order = pyblish.api.CollectorOrder + 0.01
     hosts = ["blender"]
@@ -19,99 +34,171 @@ class CollectBlenderRender(plugin.BlenderInstancePlugin):
     label = "Collect Render"
     sync_workfile_version = False
 
-    @staticmethod
-    def generate_expected_beauty(
-        render_product, frame_start, frame_end, frame_step, ext
-    ):
-        """
-        Generate the expected files for the render product for the beauty
-        render. This returns a list of files that should be rendered. It
-        replaces the sequence of `#` with the frame number.
-        """
-        path = os.path.dirname(render_product)
-        file = os.path.basename(render_product)
+    def process(self, instance: pyblish.api.Instance):
 
-        expected_files = []
+        comp_output_node: "bpy.types.CompositorNodeOutputFile" = (
+            instance.data["transientData"]["instance_node"])
+        frame_start: int = instance.data["frameStartHandle"]
+        frame_end: int = instance.data["frameEndHandle"]
+        frame_step: int = instance.data["creator_attributes"].get("step", 1)
 
-        for frame in range(frame_start, frame_end + 1, frame_step):
-            frame_str = str(frame).rjust(4, "0")
-            filename = re.sub("#+", frame_str, file)
-            expected_file = f"{os.path.join(path, filename)}.{ext}"
-            expected_files.append(expected_file.replace("\\", "/"))
-
-        return {
-            "beauty": expected_files
-        }
-
-    @staticmethod
-    def generate_expected_aovs(
-        aov_file_product, frame_start, frame_end, frame_step, ext
-    ):
-        """
-        Generate the expected files for the render product for the beauty
-        render. This returns a list of files that should be rendered. It
-        replaces the sequence of `#` with the frame number.
-        """
         expected_files = {}
+        output_paths = self.get_expected_outputs(comp_output_node)
+        is_multilayer = self.is_multilayer_exr(comp_output_node)
 
-        for aov_name, aov_file in aov_file_product:
-            path = os.path.dirname(aov_file)
-            file = os.path.basename(aov_file)
+        for output_path in output_paths:
+            if is_multilayer:
+                # Only ever a single output - we enforce the identifier to an
+                # empty string to have it considered to not split into a
+                # subname for the product
+                aov_identifier = ""
+            else:
+                aov_identifier = self.get_aov_identifier(output_path)
 
-            aov_files = []
+            expected_files[aov_identifier] = self.generate_expected_frames(
+                output_path,
+                frame_start,
+                frame_end,
+                frame_step
+            )
 
-            for frame in range(frame_start, frame_end + 1, frame_step):
-                frame_str = str(frame).rjust(4, "0")
-                filename = re.sub("#+", frame_str, file)
-                expected_file = f"{os.path.join(path, filename)}.{ext}"
-                aov_files.append(expected_file.replace("\\", "/"))
-
-            expected_files[aov_name] = aov_files
-
-        return expected_files
-
-    def process(self, instance):
         context = instance.context
-
-        instance_node = instance.data["transientData"]["instance_node"]
-        render_data = instance_node.get("render_data")
-
-        assert render_data, "No render data found."
-
-        render_product = render_data.get("render_product")
-        aov_file_product = render_data.get("aov_file_product")
-        ext = render_data.get("image_format")
-        multilayer = render_data.get("multilayer_exr")
-
-        frame_start = instance.data["frameStartHandle"]
-        frame_end = instance.data["frameEndHandle"]
-
-        expected_beauty = self.generate_expected_beauty(
-            render_product, int(frame_start), int(frame_end),
-            int(bpy.context.scene.frame_step), ext)
-
-        expected_aovs = self.generate_expected_aovs(
-            aov_file_product, int(frame_start), int(frame_end),
-            int(bpy.context.scene.frame_step), ext)
-
-        expected_files = expected_beauty | expected_aovs
-
         instance.data.update({
             "families": ["render", "render.farm"],
             "fps": context.data["fps"],
-            "byFrameStep": instance.data["creator_attributes"].get("step", 1),
-            "review": render_data.get("review", False),
-            "multipartExr": ext == "exr" and multilayer,
+            "byFrameStep": frame_step,
+            "review": instance.data.get("review", False),
+            "multipartExr": is_multilayer,
             "farm": True,
             "expectedFiles": [expected_files],
-            # OCIO not currently implemented in Blender, but the following
-            # settings are required by the schema, so it is hardcoded.
-            # TODO: Implement OCIO in Blender
-            "colorspaceConfig": "",
-            "colorspaceDisplay": "sRGB",
-            "colorspaceView": "ACES 1.0 SDR-video",
             "renderProducts": colorspace.ARenderProduct(
                 frame_start=frame_start,
                 frame_end=frame_end
             ),
         })
+
+        colorspace_data = self.get_colorspace_data(comp_output_node)
+        self.log.debug(f"Collected colorspace data: {colorspace_data}")
+        instance.data.update(colorspace_data)
+
+    def get_colorspace_data(
+        self,
+        node: "bpy.types.CompositorNodeOutputFile"
+    ) -> dict:
+        # OCIO not currently implemented in Blender, but the following
+        # settings are required by the schema, so it is hardcoded.
+        ocio_path = os.getenv("OCIO")
+        if not ocio_path:
+            # assume not color-managed, return fallback placeholder data
+            return {
+                "colorspaceConfig": "",
+                "colorspaceDisplay": "sRGB",
+                "colorspaceView": "ACES 1.0 SDR-video",
+            }
+
+        # Get from node or scene
+        if node.format.color_management == "OVERRIDE":
+            display: str = node.display_settings.display_device
+            view: str = node.view_settings.view_transform
+            look: str = node.view_settings.look
+        else:
+            display: str = bpy.context.scene.display_settings.display_device
+            view: str = bpy.context.scene.view_settings.view_transform
+            look: str = bpy.context.scene.view_settings.look
+
+        return {
+            "colorspaceConfig": ocio_path,
+            "colorspaceDisplay": display,
+            "colorspaceView": view,
+        }
+
+    def is_multilayer_exr(
+        self,
+        node: "bpy.types.CompositorNodeOutputFile"
+    ) -> bool:
+        return node.format.file_format == "OPEN_EXR_MULTILAYER"
+
+    def get_expected_outputs(
+        self,
+        node: "bpy.types.CompositorNodeOutputFile"
+    ):
+        """Return the expected output files from a compositor node output file.
+
+        The output paths are **not** converted to individual frames and will
+        still contain the `####` frame padding tokens to. So the final path
+        would still need to be constructed from the resulting path.
+
+        Returns:
+            list[str]: The full output image or sequence paths.
+
+        """
+        outputs: "list[str]" = []
+        base_path: str = node.base_path
+
+        if self.is_multilayer_exr(node):
+            # Single multi-layered EXR containing all the images as layers
+            # TODO: Collect the format and layer names contained inside
+            #  the output
+            # for layer_slot in node.layer_slots:
+            #     name = layer_slot.name
+            outputs.append(base_path)
+        else:
+            for file_slot in node.file_slots:
+                # TODO: Should we skip file slots that are not connected?
+                #  (what does blender do?)
+                # TODO: Do we need to check `file_slot.save_as_render`?
+                # TODO: Collect format from File Slot (it can override it)
+                #  however this would also need support by other publish
+                #  plug-ins to allow custom colorspace data per output AOV
+                #  (render product) within a single instance
+                # if file_slot.use_node_format:
+                #     output_format = file_slot.format
+
+                # Get full path
+                sub_path: str = file_slot.path
+                file_path = os.path.join(base_path, sub_path)
+                outputs.append(file_path)
+
+        return outputs
+
+    @staticmethod
+    def generate_expected_frames(
+        path_with_frame_token: str,
+        frame_start: int,
+        frame_end: int,
+        frame_step: int
+    ):
+        """Generate the expected files for each frame.
+
+        It replaces the sequence of `#` with the frame number.
+
+        Returns:
+            list[str]: All frames for input path.
+
+        """
+        path = os.path.dirname(path_with_frame_token)
+        file = os.path.basename(path_with_frame_token)
+        file, ext = os.path.splitext(file)
+
+        # TODO: What does blender do by default if the path does not include
+        #  the `#` token in the name?
+        expected_files = []
+        for frame in range(frame_start, frame_end + 1, frame_step):
+            # TODO: Compute padding from the path instead of assuming 4
+            frame_str = str(frame).rjust(4, "0")
+            filename = re.sub("#+", frame_str, file)
+            expected_file = f"{os.path.join(path, filename)}.{ext}"
+            expected_files.append(expected_file.replace("\\", "/"))
+
+        return expected_files
+
+    def get_aov_identifier(self, path: str) -> str:
+        # TODO: Define sensible way to compute AOV name for the publish product
+        #  based on the image outputs the comp node (when NOT multilayer EXR).
+        #  This identifier will be the suffix for the product, like:
+        #  `renderLightingMain.{aov}` -> `renderLightingMain.beauty`
+
+        # Change "/path/to/my_filename.####.exr" to "my_filename"
+        aov_identifier = os.path.basename(path).split("#", 1)[0].strip("._")
+        self.log.info(f"AOV '{aov_identifier}' from filepath: {path}")
+        return aov_identifier


### PR DESCRIPTION
## Changelog Description

Allow the Compositor's Node Output File to be the ground truth about the "output" of your render.

It should not matter whether it's the direct 3D render or whether you are doing slap-comp compisiting in-between. The idea here is that there just happens to be a node, with some input layers defined, which then end up defining the actual render products you want to publish.

## Additional review information

Currently the so called "aov" suffix to the product is defined by the filename of the layer in the compositor node output file - but we could look into other options, like using custom attributes on the node or another explicit naming option for those. The logic is currently in the `get_aov_identifier` function.

- [ ] TODO: Currently the creator 'auto-collects' from the compositor node tree - which is very different of other behavior on publish instances. We should work towards fixing that. :)

## Testing notes:

1. Build up a nice render network via the compositor node tree using the Compositor Node Output File and connecting your layers to it.
2. Go and publish.