### PR TITLE
Render path: Do not enforce backslashes to support UNC path.

### DIFF
--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import bpy
@@ -77,9 +78,7 @@ def get_render_product(output_path, name, aov_sep):
     """
     filepath = output_path / name.lstrip("/")
     render_product = f"{filepath}{aov_sep}beauty.####"
-    render_product = render_product.replace("\\", "/")
-
-    return render_product
+    return os.path.normpath(render_product)
 
 
 def set_render_format(ext, multilayer):


### PR DESCRIPTION
## Changelog Description

Render path: Do not enforce backslashes to support UNC path.

## Additional review information

Quick hotfix for #69

@jrsndl could you test this?


## Testing notes:

1. Set up rendering using UNC path
2. Render path should resolve correctly at rendertime.
