### PR TITLE
Load Image to comp or shader: fix applying colorspace 

### DIFF
--- a/client/ayon_blender/plugins/load/load_image_compositor.py
+++ b/client/ayon_blender/plugins/load/load_image_compositor.py
@@ -135,8 +135,10 @@ class LoadImageCompositor(plugin.BlenderLoader):
                 image_comp_node.frame_offset = 0
 
         # Set colorspace if representation has colorspace data
-        if representation.get("colorspaceData"):
-            colorspace: str = representation["colorspaceData"]["colorspace"]
+        colorspace_data = representation.get("data", {}).get(
+            "colorspaceData", {})
+        if colorspace_data:
+            colorspace: str = colorspace_data["colorspace"]
             if colorspace:
                 image.colorspace_settings.name = colorspace
 

--- a/client/ayon_blender/plugins/load/load_image_shader.py
+++ b/client/ayon_blender/plugins/load/load_image_shader.py
@@ -133,8 +133,10 @@ class LoadImageShaderEditor(plugin.BlenderLoader):
         image = image_texture_node.image
         representation: dict = context["representation"]
 
-        if representation.get("colorspaceData"):
-            colorspace: str = representation["colorspaceData"]["colorspace"]
+        colorspace_data = representation.get("data", {}).get(
+            "colorspaceData", {})
+        if colorspace_data:
+            colorspace: str = colorspace_data["colorspace"]
             if colorspace:
                 image.colorspace_settings.name = colorspace
 


### PR DESCRIPTION
## Changelog Description

Fix setting of `colorspace`

## Additional review information

Fixes #72

## Testing notes:

1. Load image to compositor and load image to shader should correctly set colorspace.
