### PR TITLE
Add project_name as part of the container data

### DIFF
--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -576,6 +576,7 @@ def containerise_existing(
         "namespace": namespace or '',
         "loader": str(loader),
         "representation": context["representation"]["id"],
+        "project_name": context["project"]["name"],
     }
 
     metadata_update(container, data)

--- a/client/ayon_blender/plugins/load/load_action.py
+++ b/client/ayon_blender/plugins/load/load_action.py
@@ -242,6 +242,7 @@ class BlendActionLoader(plugin.BlenderLoader):
         collection_metadata["objects"] = objects_list
         collection_metadata["libpath"] = str(libpath)
         collection_metadata["representation"] = repre_entity["id"]
+        collection_metadata["project_name"] = context["project"]["name"]
 
         bpy.ops.object.select_all(action='DESELECT')
 

--- a/client/ayon_blender/plugins/load/load_audio.py
+++ b/client/ayon_blender/plugins/load/load_audio.py
@@ -89,7 +89,8 @@ class AudioLoader(plugin.BlenderLoader):
             "parent": context["representation"]["versionId"],
             "productType": context["product"]["productType"],
             "objectName": group_name,
-            "audio": audio
+            "audio": audio,
+            "project_name": context["project"]["name"],
         }
 
         objects = []
@@ -179,6 +180,7 @@ class AudioLoader(plugin.BlenderLoader):
         metadata["representation"] = repre_entity["id"]
         metadata["parent"] = repre_entity["versionId"]
         metadata["audio"] = new_audio
+        metadata["project_name"] = context["project"]["name"]
 
     def exec_remove(self, container: Dict) -> bool:
         """Remove an audio strip from the sequence editor and the container.

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -169,6 +169,7 @@ class BlendLoader(plugin.BlenderLoader):
             "productType": context["product"]["productType"],
             "objectName": group_name,
             "members": members,
+            "project_name": context["project"]["name"],
         }
 
         container[AVALON_PROPERTY] = data
@@ -238,6 +239,7 @@ class BlendLoader(plugin.BlenderLoader):
             "representation": repre_entity["id"],
             "parent": repre_entity["versionId"],
             "members": members,
+            "project_name": context["project"]["name"],
         }
 
         imprint(asset_group, new_data)

--- a/client/ayon_blender/plugins/load/load_blendscene.py
+++ b/client/ayon_blender/plugins/load/load_blendscene.py
@@ -121,6 +121,7 @@ class BlendSceneLoader(plugin.BlenderLoader):
             "productType": context["product"]["productType"],
             "objectName": group_name,
             "members": members,
+            "project_name": context["project"]["name"],
         }
 
         container[AVALON_PROPERTY] = data
@@ -205,6 +206,7 @@ class BlendSceneLoader(plugin.BlenderLoader):
             "representation": repre_entity["id"],
             "parent": repre_entity["versionId"],
             "members": members,
+            "project_name": context["project"]["name"],
         }
 
         imprint(asset_group, new_data)

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -203,7 +203,8 @@ class CacheModelLoader(plugin.BlenderLoader):
             "asset_name": asset_name,
             "parent": context["representation"]["versionId"],
             "productType": product_type,
-            "objectName": group_name
+            "objectName": group_name,
+            "project_name": context["project"]["name"],
         }
 
         self[:] = objects
@@ -282,6 +283,7 @@ class CacheModelLoader(plugin.BlenderLoader):
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]
+        metadata["project_name"] = context["project"]["name"]
 
     def exec_remove(self, container: Dict) -> bool:
         """Remove an existing container from a Blender scene.

--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -129,6 +129,7 @@ class AbcCameraLoader(plugin.BlenderLoader):
             "parent": context["representation"]["versionId"],
             "productType": context["product"]["productType"],
             "objectName": group_name,
+            "project_name": context["project"]["name"],
         }
 
         self[:] = objects
@@ -210,6 +211,7 @@ class AbcCameraLoader(plugin.BlenderLoader):
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]
+        metadata["project_name"] = context["project"]["name"]
 
     def exec_remove(self, container: Dict) -> bool:
         """Remove an existing container from a Blender scene.

--- a/client/ayon_blender/plugins/load/load_camera_fbx.py
+++ b/client/ayon_blender/plugins/load/load_camera_fbx.py
@@ -127,7 +127,8 @@ class FbxCameraLoader(plugin.BlenderLoader):
             "asset_name": asset_name,
             "parent": context["representation"]["versionId"],
             "productType": context["product"]["productType"],
-            "objectName": group_name
+            "objectName": group_name,
+            "project_name": context["project"]["name"],
         }
 
         self[:] = objects
@@ -197,6 +198,7 @@ class FbxCameraLoader(plugin.BlenderLoader):
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]
+        metadata["project_name"] = context["project"]["name"]
 
     def exec_remove(self, container: Dict) -> bool:
         """Remove an existing container from a Blender scene.

--- a/client/ayon_blender/plugins/load/load_fbx.py
+++ b/client/ayon_blender/plugins/load/load_fbx.py
@@ -171,7 +171,8 @@ class FbxModelLoader(plugin.BlenderLoader):
             "asset_name": asset_name,
             "parent": context["representation"]["versionId"],
             "productType": context["product"]["productType"],
-            "objectName": group_name
+            "objectName": group_name,
+            "project_name": context["project"]["name"],
         }
 
         self[:] = objects
@@ -252,6 +253,7 @@ class FbxModelLoader(plugin.BlenderLoader):
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]
+        metadata["project_name"] = context["project"]["name"]
 
     def exec_remove(self, container: Dict) -> bool:
         """Remove an existing container from a Blender scene.

--- a/client/ayon_blender/plugins/load/load_image_compositor.py
+++ b/client/ayon_blender/plugins/load/load_image_compositor.py
@@ -54,6 +54,7 @@ class LoadImageCompositor(plugin.BlenderLoader):
             "namespace": namespace or '',
             "loader": str(self.__class__.__name__),
             "representation": context["representation"]["id"],
+            "project_name": context["project"]["name"],
         }
         lib.imprint(img_comp_node, data)
 
@@ -87,7 +88,8 @@ class LoadImageCompositor(plugin.BlenderLoader):
 
         # Update representation id
         lib.imprint(img_comp_node, {
-            "representation": context["representation"]["id"]
+            "representation": context["representation"]["id"],
+            "project_name": context["project"]["name"],
         })
 
     def set_source_and_colorspace(

--- a/client/ayon_blender/plugins/load/load_layout_json.py
+++ b/client/ayon_blender/plugins/load/load_layout_json.py
@@ -182,7 +182,8 @@ class JsonLayoutLoader(plugin.BlenderLoader):
             "asset_name": asset_name,
             "parent": context["representation"]["versionId"],
             "productType": context["product"]["productType"],
-            "objectName": group_name
+            "project_name": context["project"]["name"],
+            "objectName": group_name,
         }
 
         self[:] = asset_group.children
@@ -271,6 +272,7 @@ class JsonLayoutLoader(plugin.BlenderLoader):
 
         metadata["libpath"] = str(libpath)
         metadata["representation"] = repre_entity["id"]
+        metadata["project_name"] = context["project"]["name"]
 
     def exec_remove(self, container: Dict) -> bool:
         """Remove an existing container from a Blender scene.

--- a/client/ayon_blender/plugins/load/load_look.py
+++ b/client/ayon_blender/plugins/load/load_look.py
@@ -132,6 +132,7 @@ class BlendLookLoader(plugin.BlenderLoader):
 
         metadata["parent"] = context["representation"]["versionId"]
         metadata["product_type"] = context["product"]["productType"]
+        metadata["project_name"] = context["project"]["name"]
 
         nodes = list(container.objects)
         nodes.append(container)
@@ -203,6 +204,7 @@ class BlendLookLoader(plugin.BlenderLoader):
         collection_metadata["materials"] = materials
         collection_metadata["libpath"] = str(libpath)
         collection_metadata["representation"] = repre_entity["id"]
+        collection_metadata["project_name"] = context["project"]["name"]
 
     def remove(self, container: Dict) -> bool:
         collection = bpy.data.collections.get(container["objectName"])


### PR DESCRIPTION
## Changelog Description
This PR is to add project_name as part of the container data regarding to the implementation of https://github.com/ynput/ayon-core/pull/1005 

## Additional review information
Test along with the installed addon with https://github.com/ynput/ayon-core/pull/1005

## Testing notes:
1. Launch Blender
2. Load Assets from any product type(s)
