### PR TITLE
Return to global view before closing a window

### DIFF
--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -101,6 +101,8 @@ def capture(
                 view_context=True
             )
 
+        restore_global_view(window)
+
     return filename
 
 
@@ -117,7 +119,6 @@ ImageSettings = {
     },
 }
 
-
 def isolate_objects(window, objects):
     """Isolate selection"""
     deselect_all()
@@ -133,7 +134,22 @@ def isolate_objects(window, objects):
 
     deselect_all()
 
+def restore_global_view(window, isolate=None):
+    """Exit local view if active.
 
+    Blender currently does not exit localview when closing windows.
+    """
+
+    types = {"MESH", "GPENCIL"}
+    objects = [obj for obj in window.scene.objects if obj.type in types]
+
+    context = create_blender_context(selected=isolate or objects, window=window)
+
+    with bpy.context.temp_override(**context):
+        # Only toggle back if in local view
+        if bpy.context.space_data.local_view:
+            bpy.ops.view3d.localview()
+    
 def _apply_options(entity, options):
     for option, value in options.items():
         if isinstance(value, dict):

--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -101,8 +101,6 @@ def capture(
                 view_context=True
             )
 
-        restore_global_view(window)
-
     return filename
 
 
@@ -134,7 +132,7 @@ def isolate_objects(window, objects):
 
     deselect_all()
 
-def restore_global_view(window, isolate=None):
+def restore_global_view(window):
     """Exit local view if active.
 
     Blender currently does not exit localview when closing windows.
@@ -143,7 +141,7 @@ def restore_global_view(window, isolate=None):
     types = {"MESH", "GPENCIL"}
     objects = [obj for obj in window.scene.objects if obj.type in types]
 
-    context = create_blender_context(selected=isolate or objects, window=window)
+    context = create_blender_context(selected=objects, window=window)
 
     with bpy.context.temp_override(**context):
         # Only toggle back if in local view
@@ -295,4 +293,6 @@ def _independent_window():
         try:
             yield window
         finally:
+            restore_global_view(window) 
             bpy.ops.wm.window_close()
+


### PR DESCRIPTION
Blender currently is not clearing the localview when closing a window. (Known bug: https://projects.blender.org/blender/blender/issues/104069) That caused the extract review to fail due to max 16 local views are allowed.

## Changelog Description
I have added a function to restore to the global view before removing the window.

## Testing notes:
1. Create Review publish instance\
2. Publish Review 15+ times (versions up to v016)
