### PR TITLE
Removing instance of BlenderScene won't remove the scene assets.

### DIFF
--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -32,3 +32,17 @@ class CreateBlendScene(plugin.BlenderCreator):
                     instance_node.objects.link(data)
 
         return instance_node
+
+    def remove_instances(self, instances):
+
+        for instance in instances:
+            node = instance.transient_data["instance_node"]
+
+            if isinstance(node, bpy.types.Collection):
+                for children in node.children_recursive:
+                    if isinstance(children, bpy.types.Collection):
+                        bpy.data.collections.remove(children)
+                    else:
+                        bpy.data.objects.remove(children)
+
+            self._remove_instance_from_context(instance)


### PR DESCRIPTION
## Changelog Description
This PR is to fix the bug of removing BlenderScene instance also deleting the included asset inside it.
Resolve https://github.com/ynput/ayon-blender/issues/61

## Additional review information
n/a

## Testing notes:
1. Create BlenderScene Instance with your assets
2. Removing it