### PR TITLE
Version up current workfile in ayon menu

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -399,7 +399,7 @@ class SetUnitScale(bpy.types.Operator):
 
 
 class VersionUpWorkfile(LaunchQtApp):
-    """Launch Avalon Publisher."""
+    """Perform Incremental Save Workfile."""
 
     bl_idname = "wm.avalon_version_up_workfile"
     bl_label = "Version Up Workfile"

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -397,6 +397,17 @@ class SetUnitScale(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class VersionUpWorkfile(LaunchQtApp):
+    """Launch Avalon Publisher."""
+
+    bl_idname = "wm.avalon_version_up_workfile"
+    bl_label = "Version Up Workfile"
+
+    def execute(self, context):
+        version_up_current_workfile()
+        return {"FINISHED"}
+
+
 class TOPBAR_MT_avalon(bpy.types.Menu):
     """Avalon menu."""
 
@@ -439,6 +450,12 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.operator(SetUnitScale.bl_idname, text="Set Unit Scale")
         layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
+        project_name = get_current_project_name()
+        project_settings = get_project_settings(project_name)
+        if project_settings["core"]["tools"]["ayon_menu"].get(
+            "version_up_current_workfile"):
+                layout.operator(
+                    VersionUpWorkfile.bl_idname, text="Version Up Workfile")
 
 
 def draw_avalon_menu(self, context):
@@ -457,6 +474,7 @@ classes = [
     SetFrameRange,
     SetResolution,
     SetUnitScale,
+    VersionUpWorkfile,
     TOPBAR_MT_avalon,
 ]
 

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -435,6 +435,24 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
             LaunchWorkFiles.bl_idname, text=context_label
         )
         context_label_item.enabled = False
+        project_name = get_current_project_name()
+        project_settings = get_project_settings(project_name)
+        if project_settings["core"]["tools"]["ayon_menu"].get(
+            "version_up_current_workfile"):
+                layout.separator()
+                layout.operator(
+                    VersionUpWorkfile.bl_idname,
+                    text="Version Up Current Workfile"
+                )
+                wm = bpy.context.window_manager
+                keyconfigs = wm.keyconfigs
+                keymap = keyconfigs.addon.keymaps.new(name='Window', space_type='EMPTY')
+                keymap.keymap_items.new(
+                    VersionUpWorkfile.bl_idname, 'S',
+                    'PRESS', ctrl=True, alt=True
+                )
+                bpy.context.window_manager.keyconfigs.addon.keymaps.update()
+
         layout.separator()
         layout.operator(LaunchCreator.bl_idname, text="Create...")
         layout.operator(LaunchLoader.bl_idname, text="Load...")
@@ -451,13 +469,6 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         layout.operator(SetUnitScale.bl_idname, text="Set Unit Scale")
         layout.separator()
         layout.operator(LaunchWorkFiles.bl_idname, text="Work Files...")
-        project_name = get_current_project_name()
-        project_settings = get_project_settings(project_name)
-        if project_settings["core"]["tools"]["ayon_menu"].get(
-            "version_up_current_workfile"):
-                layout.operator(
-                    VersionUpWorkfile.bl_idname, text="Version Up Current Workfile")
-
 
 def draw_avalon_menu(self, context):
     """Draw the Avalon menu in the top bar."""

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -23,7 +23,8 @@ from ayon_core.pipeline import (
     get_current_project_name
 )
 from ayon_core.pipeline.context_tools import (
-    get_current_task_entity
+    get_current_task_entity,
+    version_up_current_workfile
 )
 from ayon_core.tools.utils import host_tools
 

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -442,7 +442,7 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
                 layout.separator()
                 layout.operator(
                     VersionUpWorkfile.bl_idname,
-                    text="Version Up Current Workfile"
+                    text="Version Up Workfile"
                 )
                 wm = bpy.context.window_manager
                 keyconfigs = wm.keyconfigs

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -455,7 +455,7 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         if project_settings["core"]["tools"]["ayon_menu"].get(
             "version_up_current_workfile"):
                 layout.operator(
-                    VersionUpWorkfile.bl_idname, text="Version Up Workfile")
+                    VersionUpWorkfile.bl_idname, text="Version Up Current Workfile")
 
 
 def draw_avalon_menu(self, context):


### PR DESCRIPTION
## Changelog Description
This PR is to add version 
Resolve https://github.com/ynput/ayon-blender/issues/75

## Additional review information
Should we introduce the validator or integrator to check/save workfile with version?

## Testing notes:
1. Following the testing step in 75 to enable version up workfile
2. Launch Blender and `version up current workfile` would show up in the menu
