### PR TITLE
backward compatibility for blender eevee renderer newer than 4.2.2

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -577,3 +577,10 @@ def get_cache_modifiers(obj, modifier_type="MESH_SEQUENCE_CACHE"):
                                    if modifier.type == modifier_type]
                 modifiers_dict[ob.name] = cache_modifiers
     return modifiers_dict
+
+
+def get_blender_version():
+    """Get Blender Version
+    """
+    major, minor, subversion = bpy.app.version
+    return major, minor, subversion

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -119,11 +119,15 @@ def set_render_passes(settings, renderer, view_layers):
     existing_aov_list = set(existing_aov_options(renderer, view_layers))
     aov_list = aov_list.union(existing_aov_list)
     custom_passes = settings["blender"]["RenderSettings"]["custom_passes"]
+    ver_major, ver_minor, _ = lib.get_blender_version()
     # Common passes for both renderers
     for vl in view_layers:
         if renderer == "BLENDER_EEVEE":
             # Eevee exclusive passes
             aov_options = get_aov_options(renderer)
+            # TODO: Remove compatibility for 3.6.x LTS version
+            if ver_major <= 3 and ver_minor <= 6:
+                aov_options.pop("combined")
             eevee_attrs = ["use_pass_shadow", "cryptomatte_accurate"]
             for pass_name, attr in aov_options.items():
                 target = vl if attr in eevee_attrs else vl.eevee

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -119,7 +119,6 @@ def set_render_passes(settings, renderer, view_layers):
     existing_aov_list = set(existing_aov_options(renderer, view_layers))
     aov_list = aov_list.union(existing_aov_list)
     custom_passes = settings["blender"]["RenderSettings"]["custom_passes"]
-    ver_major, ver_minor, _ = lib.get_blender_version()
     # Common passes for both renderers
     for vl in view_layers:
         if renderer == "BLENDER_EEVEE":

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -125,12 +125,12 @@ def set_render_passes(settings, renderer, view_layers):
         if renderer == "BLENDER_EEVEE":
             # Eevee exclusive passes
             aov_options = get_aov_options(renderer)
-            # TODO: Remove compatibility for 3.6.x LTS version
-            if ver_major <= 3 and ver_minor <= 6:
-                aov_options.pop("combined")
-            eevee_attrs = ["use_pass_shadow", "cryptomatte_accurate"]
+            eevee_attrs = [
+                "use_pass_shadow", "use_pass_volume_direct",
+                "cryptomatte_accurate"
+            ]
             for pass_name, attr in aov_options.items():
-                target = vl if attr in eevee_attrs else vl.eevee
+                target = vl.eevee if attr in eevee_attrs else vl
                 setattr(target, attr, pass_name in aov_list)
         elif renderer == "CYCLES":
             # Cycles exclusive passes
@@ -142,6 +142,9 @@ def set_render_passes(settings, renderer, view_layers):
             ]
             for pass_name, attr in aov_options.items():
                 target = vl.cycles if attr in cycle_attrs else vl
+                # TODO: Remove compatibility for 3.6.x LTS version
+                if ver_major <= 3 and ver_minor <= 6:
+                    target = vl
                 setattr(target, attr, pass_name in aov_list)
 
         aovs_names = [aov.name for aov in vl.aovs]

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -142,9 +142,6 @@ def set_render_passes(settings, renderer, view_layers):
             ]
             for pass_name, attr in aov_options.items():
                 target = vl.cycles if attr in cycle_attrs else vl
-                # TODO: Remove compatibility for 3.6.x LTS version
-                if ver_major <= 3 and ver_minor <= 6:
-                    target = vl
                 setattr(target, attr, pass_name in aov_list)
 
         aovs_names = [aov.name for aov in vl.aovs]

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -125,11 +125,16 @@ def set_render_passes(settings, renderer, view_layers):
             # Eevee exclusive passes
             aov_options = get_aov_options(renderer)
             eevee_attrs = [
-                "use_pass_shadow", "use_pass_volume_direct",
-                "cryptomatte_accurate"
+                "use_pass_bloom",
+                "use_pass_transparent",
+                "use_pass_volume_direct"
             ]
             for pass_name, attr in aov_options.items():
                 target = vl.eevee if attr in eevee_attrs else vl
+                ver_major, ver_minor, _ = lib.get_blender_version()
+                if ver_major >= 3 and ver_minor > 6:
+                    if attr == "use_pass_bloom":
+                        continue
                 setattr(target, attr, pass_name in aov_list)
         elif renderer == "CYCLES":
             # Cycles exclusive passes

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -5,6 +5,7 @@ import bpy
 
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import get_current_project_name
+from . import lib
 
 
 def get_default_render_folder(settings):
@@ -420,6 +421,11 @@ def prepare_rendering(asset_group):
     ext = get_image_format(settings)
     multilayer = get_multilayer(settings)
     renderer = get_renderer(settings)
+    ver_major, ver_minor, _ = lib.get_blender_version()
+    if renderer == "BLENDER_EEVEE" and (
+        ver_major >= 4 and ver_minor >=2
+    ):
+        renderer = "BLENDER_EEVEE_NEXT"
     compositing = get_compositing(settings)
 
     set_render_format(ext, multilayer)


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-blender/issues/51
Add the compatible check on the renderer when it is set to EEVEE in regards to the recent changes on the renderer name in bpy.

## Additional review information
n/a

## Testing notes:
1. Create Render Instance with EEVEE being as default renderer in ayon setting
2. Should be working.
