### PR TITLE
Make sure the deadline setting correctly propagated to publisher UI

### DIFF
--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -353,7 +353,8 @@ def set_node_tree(
         # and link it
         for render_layer_node, passes in render_aovs_dict.items():
             render_layer = render_layer_node.layer
-            aov_file_products[render_layer] = []
+            if not aov_file_products.get(render_layer, []):
+                aov_file_products[render_layer] = []
             for rpass in passes:
                 slot, filepath = _create_aov_slot(
                     name, aov_sep, slots, rpass.name, multi_exr, output_path, render_layer)
@@ -381,7 +382,7 @@ def set_node_tree(
     output.name = "AYON File Output"
     output.label = "AYON File Output"
 
-    return [] if multi_exr else aov_file_products
+    return {} if multi_exr else aov_file_products
 
 
 def imprint_render_settings(node, data):

--- a/client/ayon_blender/plugins/publish/collect_render.py
+++ b/client/ayon_blender/plugins/publish/collect_render.py
@@ -80,8 +80,7 @@ class CollectBlenderRender(plugin.BlenderInstancePlugin):
         for view_layer in bpy.context.scene.view_layers:
             viewlayer_name = view_layer.name
             rn_product = render_product[viewlayer_name]
-            aov_product = aov_file_product[viewlayer_name]
-            self.log.debug(f"aov: {aov_product}")
+            aov_product = aov_file_product[viewlayer_name] if aov_file_product else {}
             viewlayer_product_name = get_product_name(
                 context.data["projectName"],
                 task_entity["name"],
@@ -129,6 +128,7 @@ class CollectBlenderRender(plugin.BlenderInstancePlugin):
                     frame_start=frame_start,
                     frame_end=frame_end
                 ),
+                "publish_attributes": instance.data["publish_attributes"]
             })
             instance.append(rn_layer_instance)
             self.log.debug([expected_files])

--- a/client/ayon_blender/plugins/publish/validate_deadline_publish.py
+++ b/client/ayon_blender/plugins/publish/validate_deadline_publish.py
@@ -104,10 +104,11 @@ class ValidateDeadlinePublish(
         aov_file_product = render_data.get("aov_file_product")
         updated_render_product = update_render_product(
             container.name, new_output_dir, render_product)
-        updated_aov_file_product = update_render_product(
-            container.name, new_output_dir, aov_file_product)
         render_data["render_product"] = updated_render_product
-        render_data["aov_file_product"] = updated_aov_file_product
+        if aov_file_product:
+            updated_aov_file_product = update_render_product(
+                container.name, new_output_dir, aov_file_product)
+            render_data["aov_file_product"] = updated_aov_file_product
 
         bpy.context.scene.render.filepath = "/tmp/"
         bpy.ops.wm.save_as_mainfile(filepath=bpy.data.filepath)


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the deadline setting correctly propagated to publisher UI and fix the small bug on collecting aov files when the multilayer is on.
Resolve https://github.com/ynput/ayon-blender/issues/88

## Additional review information
n/a

## Testing notes:
1. Launch Blender
2. Create Render Instance with mutlilayer options on in ayon setting
3. Publish
4. The deadline parameter should be propagated correctly accordingly to the Publisher UI.
