### PR TITLE
Load Shader material ignore empty material slots

### DIFF
--- a/client/ayon_blender/plugins/load/load_image_shader.py
+++ b/client/ayon_blender/plugins/load/load_image_shader.py
@@ -52,7 +52,12 @@ class LoadImageShaderEditor(plugin.BlenderLoader):
 
         # If the currently selected object has one or more materials, let's use
         # the first one. If it has no material, let's create a new one.
-        if not cur_obj.data.materials:
+        materials = [
+            material for material in cur_obj.data.materials
+            # Ignore empty material slots
+            if material is not None
+        ]
+        if not materials:
             # Create a new material
             current_material = bpy.data.materials.new(name="material")
             current_material.use_nodes = True


### PR DESCRIPTION
## Changelog Description

Ignore empty material slots

## Additional review information

Avoids error:
```python
Traceback (most recent call last):

  File "C:\Users\robert\AppData\Local\Ynput\AYON\addons\blender_0.2.8\ayon_blender\api\ops.py", line 129, in execute
    result = callback(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "C:\Users\robert\AppData\Local\Ynput\AYON\addons\blender_0.2.8\ayon_blender\api\plugin.py", line 495, in _load
    nodes = self.process_asset(
            ^^^^^^^^^^^^^^^^^^^

  File "C:\Users\robert\AppData\Local\Ynput\AYON\addons\blender_0.2.8\ayon_blender\plugins\load\load_image_shader.py", line 62, in process_asset
    current_material.use_nodes = True
    ^^^^^^^^^^^^^^^^^^^^^^^^^^

AttributeError: 'NoneType' object has no attribute 'use_nodes'
```

As reported [here](https://discord.com/channels/517362899170230292/563751989075378201/1335969122739028020)

## Testing notes:

1. Import texture to blender should work, even if a first empty material slot is present.
