### PR TITLE
Fix operator for Blender 4.4+

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -200,7 +200,8 @@ class LaunchQtApp(bpy.types.Operator):
     _init_kwargs: Optional[Dict] = dict()
     bl_idname: str = None
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if self.bl_idname is None:
             raise NotImplementedError("Attribute `bl_idname` must be set!")
         print(f"Initialising {self.bl_idname}...")


### PR DESCRIPTION
## Changelog Description

Fix support for Blender 4.4+

## Additional review information

See: https://developer.blender.org/docs/release_notes/4.4/python_api/

> Python-defined classes based on Blender types (like `Operator`, `PropertyGroup`, etc.) that define their own `__new__`/`__init__` constructors must now call the parent's matching function, and pass on generic positional and keyword arguments.

Fix https://github.com/ynput/ayon-blender/issues/101#issuecomment-2679138882

## Testing notes:

1. Download Blender 4.4 beta
2. Launch with AYON integration
