### PR TITLE
Extract Fbx Animation: `bake_action_objects` support Blender 4.1+

### DIFF
--- a/client/ayon_blender/plugins/publish/extract_fbx_animation.py
+++ b/client/ayon_blender/plugins/publish/extract_fbx_animation.py
@@ -8,6 +8,7 @@ import bpy_extras.anim_utils
 from ayon_core.pipeline import publish
 from ayon_blender.api import plugin
 from ayon_blender.api.pipeline import AVALON_PROPERTY
+from ayon_blender.api.lib import get_blender_version
 
 
 def get_all_parents(obj):
@@ -132,13 +133,34 @@ class ExtractAnimationFBX(
         max_frame = min(starting_frames)
         min_frame = max(ending_frames)
 
-        # We bake the copy of the current action for each object
-        bpy_extras.anim_utils.bake_action_objects(
-            object_action_pairs,
-            frames=range(int(min_frame), int(max_frame)),
-            do_object=False,
-            do_clean=False
-        )
+        if get_blender_version[0] >= 4:
+            # We bake the copy of the current action for each object
+            bake_options = bpy_extras.anim_utils.BakeOptions(
+                only_selected=True,
+                do_pose=True,
+                do_object=False,
+                do_visual_keying=True,
+                do_constraint_clear=True,
+                do_parents_clear=True,
+                do_clean=False,
+                do_location=True,
+                do_rotation=True,
+                do_scale=True,
+                do_bbone=True,
+                do_custom_props=True
+            )
+            bpy_extras.anim_utils.bake_action_objects(
+                object_action_pairs,
+                frames=range(int(min_frame), int(max_frame)),
+                bake_options=bake_options
+            )
+        else:
+            bpy_extras.anim_utils.bake_action_objects(
+                object_action_pairs,
+                frames=range(int(min_frame), int(max_frame)),
+                do_object=False,
+                do_clean=False
+            )
 
         for obj in bpy.data.objects:
             obj.select_set(False)

--- a/client/ayon_blender/plugins/publish/extract_fbx_animation.py
+++ b/client/ayon_blender/plugins/publish/extract_fbx_animation.py
@@ -133,8 +133,8 @@ class ExtractAnimationFBX(
         max_frame = min(starting_frames)
         min_frame = max(ending_frames)
 
-        ver_major, ver_min, _ = get_blender_version()
-        if ver_major >= 4 and ver_min >= 1:
+        blender_version = get_blender_version()
+        if blender_version >= (4, 1, 0):
             # We bake the copy of the current action for each object
             bake_options = bpy_extras.anim_utils.BakeOptions(
                 only_selected=False,

--- a/client/ayon_blender/plugins/publish/extract_fbx_animation.py
+++ b/client/ayon_blender/plugins/publish/extract_fbx_animation.py
@@ -133,7 +133,8 @@ class ExtractAnimationFBX(
         max_frame = min(starting_frames)
         min_frame = max(ending_frames)
 
-        if get_blender_version[0] >= 4:
+        ver_major, _, _ = get_blender_version()
+        if ver_major >= 4:
             # We bake the copy of the current action for each object
             bake_options = bpy_extras.anim_utils.BakeOptions(
                 only_selected=True,

--- a/client/ayon_blender/plugins/publish/extract_fbx_animation.py
+++ b/client/ayon_blender/plugins/publish/extract_fbx_animation.py
@@ -133,16 +133,16 @@ class ExtractAnimationFBX(
         max_frame = min(starting_frames)
         min_frame = max(ending_frames)
 
-        ver_major, _, _ = get_blender_version()
-        if ver_major >= 4:
+        ver_major, ver_min, _ = get_blender_version()
+        if ver_major >= 4 and ver_min >= 1:
             # We bake the copy of the current action for each object
             bake_options = bpy_extras.anim_utils.BakeOptions(
-                only_selected=True,
+                only_selected=False,
                 do_pose=True,
                 do_object=False,
                 do_visual_keying=True,
-                do_constraint_clear=True,
-                do_parents_clear=True,
+                do_constraint_clear=False,
+                do_parents_clear=False,
                 do_clean=False,
                 do_location=True,
                 do_rotation=True,


### PR DESCRIPTION
## Changelog Description
This PR is to fix the Attribute Error shown with `bake_action_objects`  due to the changes of the argument `bakeOptions`

## Additional review information
Related to https://github.com/ynput/ayon-blender/pull/104

## Testing notes:
1. Launch Blender 4.0 and 3.X.X 
2. Create Animation and publish
3. Both should be published successfully
