### PR TITLE
Publishing BlenderScene product should strip namespace and container data 

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -617,7 +617,12 @@ def strip_namespace(containers):
     ]
     original_namespaces = {}
     for node in nodes:
-        for child in node.children_recursive:
+        if isinstance(node, bpy.types.Collection):
+            children = node.children_recursive
+        elif isinstance(node, bpy.types.Object):
+            children = node.children
+
+        for child in children:
             original_name = child.name
             if ":" not in original_name:
                 continue

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -621,14 +621,14 @@ def strip_namespace():
             original_name = children.name
             namespace, name = original_name.rsplit(':', 1)
             children.name = name
-            namespace_dict[node] = namespace
+            namespace_dict[children] = namespace
 
     try:
         yield
 
     finally:
         for node in nodes:
-            namespace = namespace_dict[node]
             for children in node.children_recursive:
+                namespace = namespace_dict[children]
                 name = children.name
                 children.name = f"{namespace}:{name}"

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -590,11 +590,11 @@ def get_blender_version():
 
 
 @contextlib.contextmanager
-def strip_container_data():
+def strip_container_data(containers):
     """Remove container data during context
     """
     container_data = {}
-    for container in pipeline.ls():
+    for container in containers:
         node = container["node"]
         container_data[node] = dict(
             node.get(pipeline.AVALON_PROPERTY)
@@ -609,11 +609,11 @@ def strip_container_data():
 
 
 @contextlib.contextmanager
-def strip_namespace():
+def strip_namespace(containers):
     """Strip namespace during context
     """
     nodes = [
-        container["node"] for container in pipeline.ls()
+        container["node"] for container in containers
     ]
     namespace_dict = {}
     for node in nodes:

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -615,20 +615,18 @@ def strip_namespace(containers):
     nodes = [
         container["node"] for container in containers
     ]
-    namespace_dict = {}
+    original_namespaces = {}
     for node in nodes:
-        for children in node.children_recursive:
-            original_name = children.name
+        for child in node.children_recursive:
+            original_name = child.name
+            if ":" not in original_name:
+                continue
             namespace, name = original_name.rsplit(':', 1)
-            children.name = name
-            namespace_dict[children] = namespace
+            child.name = name
+            original_namespaces[child] = namespace
 
     try:
         yield
-
     finally:
-        for node in nodes:
-            for children in node.children_recursive:
-                namespace = namespace_dict[children]
-                name = children.name
-                children.name = f"{namespace}:{name}"
+        for node, original_namespace in original_namespaces.items():
+           node.name = f"{namespace}:{name}"

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -636,4 +636,4 @@ def strip_namespace(containers):
         yield
     finally:
         for node, original_namespace in original_namespaces.items():
-           node.name = f"{original_namespace}:{name}"
+            node.name = f"{original_namespace}:{name}"

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -629,4 +629,4 @@ def strip_namespace(containers):
         yield
     finally:
         for node, original_namespace in original_namespaces.items():
-           node.name = f"{namespace}:{name}"
+           node.name = f"{original_namespace}:{name}"

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -621,6 +621,8 @@ def strip_namespace(containers):
             children = node.children_recursive
         elif isinstance(node, bpy.types.Object):
             children = node.children
+        else:
+            raise TypeError(f"Unsupported type: {node} ({type(node)})")
 
         for child in children:
             original_name = child.name

--- a/client/ayon_blender/plugins/publish/extract_blend.py
+++ b/client/ayon_blender/plugins/publish/extract_blend.py
@@ -65,7 +65,7 @@ class ExtractBlend(
                     if node.image and node.image.packed_file is None:
                         node.image.pack()
 
-        containers = ls()
+        containers = list(ls())
         with contextlib.ExitStack() as stack:
             stack.enter_context(strip_namespace(containers))
             stack.enter_context(strip_container_data(containers))

--- a/client/ayon_blender/plugins/publish/extract_blend.py
+++ b/client/ayon_blender/plugins/publish/extract_blend.py
@@ -1,9 +1,14 @@
 import os
+import contextlib
 
 import bpy
 
 from ayon_core.pipeline import publish
 from ayon_blender.api import plugin
+from ayon_blender.api.lib import (
+    strip_container_data,
+    strip_namespace
+)
 
 
 class ExtractBlend(
@@ -58,8 +63,12 @@ class ExtractBlend(
                     # and pack it if not.
                     if node.image and node.image.packed_file is None:
                         node.image.pack()
-
-        bpy.data.libraries.write(filepath, data_blocks, compress=self.compress)
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(strip_namespace())
+            stack.enter_context(strip_container_data())
+            bpy.data.libraries.write(
+                filepath, data_blocks, compress=self.compress
+            )
 
         if "representations" not in instance.data:
             instance.data["representations"] = []

--- a/client/ayon_blender/plugins/publish/extract_blend.py
+++ b/client/ayon_blender/plugins/publish/extract_blend.py
@@ -5,6 +5,7 @@ import bpy
 
 from ayon_core.pipeline import publish
 from ayon_blender.api import plugin
+from ayon_blender.api.pipeline import ls
 from ayon_blender.api.lib import (
     strip_container_data,
     strip_namespace
@@ -63,9 +64,11 @@ class ExtractBlend(
                     # and pack it if not.
                     if node.image and node.image.packed_file is None:
                         node.image.pack()
+
+        containers = ls()
         with contextlib.ExitStack() as stack:
-            stack.enter_context(strip_namespace())
-            stack.enter_context(strip_container_data())
+            stack.enter_context(strip_namespace(containers))
+            stack.enter_context(strip_container_data(containers))
             bpy.data.libraries.write(
                 filepath, data_blocks, compress=self.compress
             )

--- a/client/ayon_blender/plugins/publish/extract_blend.py
+++ b/client/ayon_blender/plugins/publish/extract_blend.py
@@ -67,8 +67,8 @@ class ExtractBlend(
 
         containers = list(ls())
         with contextlib.ExitStack() as stack:
-            stack.enter_context(strip_namespace(containers))
             stack.enter_context(strip_container_data(containers))
+            stack.enter_context(strip_namespace(containers))
             bpy.data.libraries.write(
                 filepath, data_blocks, compress=self.compress
             )


### PR DESCRIPTION
## Changelog Description
This PR is to make sure publishing blenderScene product will strip namespace and container data
Resolve https://github.com/ynput/ayon-blender/issues/113


## Additional review information
Make sure testing the scenarios below:
1. Publish with loaded asset
2. Publish without loaded asset
3. Publish with or without loaded asset

## Testing notes:
1. Launch Blender 
4. Create BlenderScene product with/without the loaded assets
5. Publish
6. Create New Scene in Blender
7. Load the published asset
