### PR TITLE
Load fbx: Checking objects already in scene collection during loading

### DIFF
--- a/client/ayon_blender/plugins/load/load_fbx.py
+++ b/client/ayon_blender/plugins/load/load_fbx.py
@@ -59,6 +59,8 @@ class FbxModelLoader(plugin.BlenderLoader):
         if blender_version >= (4, 5, 0):
             bpy.ops.wm.fbx_import(filepath=libpath)
         else:
+            # TODO: make sure it works with the color management
+            # in 4.4 or elder version
             bpy.ops.import_scene.fbx(filepath=libpath)
 
         parent = bpy.context.scene.collection


### PR DESCRIPTION
## Changelog Description
This PR is to ensure scene collection would not link duplicate active objects in the scene collection thus gives error.
Resolves https://github.com/ynput/ayon-blender/issues/121

## Additional review information
n/a

## Testing notes:
1. Load fbx
2. Should be working
