### PR TITLE
Fix `CollectFileDependencies` with recent `ayon-deadline` releases

### DIFF
--- a/client/ayon_blender/plugins/publish/collect_file_dependencies.py
+++ b/client/ayon_blender/plugins/publish/collect_file_dependencies.py
@@ -16,8 +16,16 @@ class CollectFileDependencies(pyblish.api.ContextPlugin):
     @classmethod
     def apply_settings(cls, project_settings):
         # Disable plug-in if not used for deadline submission anyway
-        settings = project_settings["deadline"]["publish"]["BlenderSubmitDeadline"]  # noqa
-        cls.enabled = settings.get("asset_dependencies", True)
+        # Note: This setting has been removed in `ayon-deadline` with
+        #   https://github.com/ynput/ayon-deadline/pull/49
+        #   but the logic here is kept for compatibility with older releases.
+        cls.enabled = (
+            project_settings
+            .get("deadline", {})
+            .get("publish", {})
+            .get("BlenderSubmitDeadline", {})
+            .get("asset_dependencies", True)
+        )
 
     def process(self, context):
         dependencies = set()


### PR DESCRIPTION
## Changelog Description

Fix `CollectFileDependencies` with recent `ayon-deadline` releases since deadline addon https://github.com/ynput/ayon-deadline/pull/49 or if `ayon-deadline is not available (e.g. addon not in bundle)

## Additional review information

Should avoid error:
```python
*** WRN: >>> { filter_pyblish_plugins }: [  FAILED to apply settings on plugin CollectFileDependencies  ]
=======================
'BlenderSubmitDeadline'
=======================
Traceback (most recent call last):
  File "F:\dev\ayon-core\client\ayon_core\pipeline\publish\lib.py", line 452, in filter_pyblish_plugins
    plugin.apply_settings(project_settings)
  File "F:\dev\ayon-blender\client\ayon_blender\plugins\publish\collect_file_dependencies.py", line 19, in apply_settings
    settings = project_settings[ "deadline"]["publish"]["BlenderSubmitDeadline" ]  # noqa
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyERROR: 'BlenderSubmitDeadline'
```

Note: **It may** actually be that in current `develop` this didn't actually work anyway because the product type for [CreateRender is set to `renderlayer`](https://github.com/ynput/ayon-blender/blob/develop/client/ayon_blender/plugins/create/create_render.py#L15) and not `render`. Although it's set during publishing [to `render` on the instance data](https://github.com/ynput/ayon-blender/blob/develop/client/ayon_blender/plugins/publish/collect_render.py#L77). Note that in the upcoming render refactor it's `render` directly in https://github.com/ynput/ayon-blender/pull/67 in the Creator.

## Testing notes:

1. Collecting file dependencies for deadline submissions should work.
2. Disabling it (via Job Info profile) should also work.
