### PR TITLE
Supports stripping namespace for shader nodes for texture image

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -621,6 +621,8 @@ def strip_namespace(containers):
             children = node.children_recursive
         elif isinstance(node, bpy.types.Object):
             children = node.children
+        elif isinstance(node, bpy.types.ShaderNodeTexImage):
+            children = [node]
         else:
             raise TypeError(f"Unsupported type: {node} ({type(node)})")
 

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -621,7 +621,7 @@ def strip_namespace(containers):
             children = node.children_recursive
         elif isinstance(node, bpy.types.Object):
             children = node.children
-        elif isinstance(node, bpy.types.ShaderNodeTexImage):
+        elif isinstance(node, bpy.types.Node):
             children = [node]
         else:
             raise TypeError(f"Unsupported type: {node} ({type(node)})")

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -623,6 +623,8 @@ def strip_namespace(containers):
             children = node.children
         elif isinstance(node, bpy.types.Node):
             children = [node]
+        elif isinstance(node, bpy.types.ShaderNodeTexImage):
+            children = [node]
         else:
             raise TypeError(f"Unsupported type: {node} ({type(node)})")
 


### PR DESCRIPTION
## Changelog Description
This PR is to add support for striping namespace for shader nodes with texture images when extracting blend scene
Fixes https://github.com/ynput/ayon-blender/issues/116

## Additional review information
n/a

## Testing notes:
1. Create Rig/BlendScene with shader nodes(texture-image based) 
2. Publish
