### PR TITLE
 Collect the children recursive of the instances when instance node is Collection

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -313,7 +313,7 @@ def get_selected_collections():
 
 def get_selection(
         include_collections: bool = False,
-        include_object_children_recursive: bool = True
+        include_object_children_recursive: bool = False
     )-> List[Union[bpy.types.Object, bpy.types.Collection]]:
     """
     Returns a list of selected objects in the current Blender scene.

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -311,10 +311,7 @@ def get_selected_collections():
     return [id for id in ids if isinstance(id, bpy.types.Collection)]
 
 
-def get_selection(
-        include_collections: bool = False,
-        selected_hierarchies: bool = False
-    )-> List[Union[bpy.types.Object, bpy.types.Collection]]:
+def get_selection(include_collections: bool = False)-> List[Union[bpy.types.Object, bpy.types.Collection]]:
     """
     Returns a list of selected objects in the current Blender scene.
 
@@ -332,21 +329,21 @@ def get_selection(
 
     if include_collections:
         selection.update(get_selected_collections())
-
-    if selected_hierarchies:
-        def collect_hierarchy(obj, collected):
-            for child in obj.children:
-                if child not in collected:
-                    collected.add(child)
-                    collect_hierarchy(child, collected)
-
-        hierarchy_set = set()
-        for obj in selection:
-            collect_hierarchy(obj, hierarchy_set)
-
-        selection.update(hierarchy_set)
+    selection.update(get_object_children_recursive(selection))
 
     return list(selection)
+
+
+def get_object_children_recursive(objects: set[bpy.types.Object]) -> set[bpy.types.Object]:
+    """Return all object children of any objects in the inputs.
+
+    Any input that is not a `bpy.types.Object` is skipped."""
+    children = set()
+    for obj in objects:
+        if isinstance(obj, bpy.types.Object):
+            children.update(obj.children_recursive)
+    return children
+
 
 @contextlib.contextmanager
 def maintained_selection():

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -311,39 +311,6 @@ def get_selected_collections():
     return [id for id in ids if isinstance(id, bpy.types.Collection)]
 
 
-def get_top_objects_selections()-> List[bpy.types.Object]:
-    """Get the top hierarchies of the selections
-
-    Args:
-        selections (List[Union[bpy.types.Object]]): selected objects
-
-    Returns:
-        List[bpy.types.Object]: top objects
-    """
-    selections = get_selection()
-    top_parents = {
-        obj: get_top_parent(obj) for obj in selections
-    }
-    top_object = sorted(
-        selections, key=lambda o: (o == top_parents[o], o.name), reverse=True
-    )
-    return top_object
-
-
-def get_top_parent(obj: bpy.types.Object) -> bpy.types.Object:
-    """Get top parent with iteration
-
-    Args:
-        obj (bpy.types.Object): Object
-
-    Returns:
-        bpy.types.Object: Top object
-    """
-    while obj.parent:
-        obj = obj.parent
-    return obj
-
-
 def get_selection(
         include_collections: bool = False,
         include_object_children_recursive: bool = True

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -311,9 +311,42 @@ def get_selected_collections():
     return [id for id in ids if isinstance(id, bpy.types.Collection)]
 
 
+def get_top_objects_selections()-> List[bpy.types.Object]:
+    """Get the top hierarchies of the selections
+
+    Args:
+        selections (List[Union[bpy.types.Object]]): selected objects
+
+    Returns:
+        List[bpy.types.Object]: top objects
+    """
+    selections = get_selection()
+    top_parents = {
+        obj: get_top_parent(obj) for obj in selections
+    }
+    top_object = sorted(
+        selections, key=lambda o: (o == top_parents[o], o.name), reverse=True
+    )
+    return top_object
+
+
+def get_top_parent(obj: bpy.types.Object) -> bpy.types.Object:
+    """Get top parent with iteration
+
+    Args:
+        obj (bpy.types.Object): Object
+
+    Returns:
+        bpy.types.Object: Top object
+    """
+    while obj.parent:
+        obj = obj.parent
+    return obj
+
+
 def get_selection(
         include_collections: bool = False,
-        include_object_children_recursive: bool = False
+        include_object_children_recursive: bool = True
     )-> List[Union[bpy.types.Object, bpy.types.Collection]]:
     """
     Returns a list of selected objects in the current Blender scene.
@@ -328,7 +361,9 @@ def get_selection(
         List[Union[bpy.types.Object,
         bpy.types.Collection]]: Selected objects and optionally collections.
     """
-    selection = set(obj for obj in bpy.context.scene.objects if obj.select_get())
+    selection = {
+        obj for obj in bpy.context.scene.objects if obj.select_get()
+    }
 
     if include_collections:
         selection.update(get_selected_collections())

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -311,15 +311,18 @@ def get_selected_collections():
     return [id for id in ids if isinstance(id, bpy.types.Collection)]
 
 
-def get_selection(include_collections: bool = False)-> List[Union[bpy.types.Object, bpy.types.Collection]]:
+def get_selection(
+        include_collections: bool = False,
+        include_object_children_recursive: bool = True
+    )-> List[Union[bpy.types.Object, bpy.types.Collection]]:
     """
     Returns a list of selected objects in the current Blender scene.
 
     Args:
         include_collections (bool, optional): Whether to include selected
         collections in the result. Defaults to False.
-        selected_hierarchies (bool): Whether to include all children
-        of selected objects.
+        include_object_children_recursive (bool, optional): Whether to include all
+        hierarchies of selected objects.
 
     Returns:
         List[Union[bpy.types.Object,
@@ -329,7 +332,8 @@ def get_selection(include_collections: bool = False)-> List[Union[bpy.types.Obje
 
     if include_collections:
         selection.update(get_selected_collections())
-    selection.update(get_object_children_recursive(selection))
+    if include_object_children_recursive:
+        selection.update(get_object_children_recursive(selection))
 
     return list(selection)
 

--- a/client/ayon_blender/plugins/create/create_action.py
+++ b/client/ayon_blender/plugins/create/create_action.py
@@ -27,7 +27,9 @@ class CreateAction(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            for obj in lib.get_selection():
+            for obj in lib.get_selection(
+                include_object_children_recursive=True
+            ):
                 if (obj.animation_data is not None
                         and obj.animation_data.action is not None):
 

--- a/client/ayon_blender/plugins/create/create_animation.py
+++ b/client/ayon_blender/plugins/create/create_animation.py
@@ -20,7 +20,9 @@ class CreateAnimation(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            selected = lib.get_selection()
+            selected = lib.get_selection(
+                include_object_children_recursive=True
+            )
             for obj in selected:
                 collection.objects.link(obj)
         elif pre_create_data.get("asset_group"):

--- a/client/ayon_blender/plugins/create/create_animation.py
+++ b/client/ayon_blender/plugins/create/create_animation.py
@@ -20,7 +20,7 @@ class CreateAnimation(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            selected = lib.get_selection(include_object_children_recursive=True)
+            selected = lib.get_selection()
             for obj in selected:
                 collection.objects.link(obj)
         elif pre_create_data.get("asset_group"):

--- a/client/ayon_blender/plugins/create/create_animation.py
+++ b/client/ayon_blender/plugins/create/create_animation.py
@@ -20,7 +20,7 @@ class CreateAnimation(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            selected = lib.get_selection()
+            selected = lib.get_selection(include_object_children_recursive=True)
             for obj in selected:
                 collection.objects.link(obj)
         elif pre_create_data.get("asset_group"):

--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -24,7 +24,10 @@ class CreateBlendScene(plugin.BlenderCreator):
                                        pre_create_data)
 
         if pre_create_data.get("use_selection"):
-            selection = lib.get_selection(include_collections=True)
+            selection = lib.get_selection(
+                include_collections=True,
+                include_object_children_recursive=True
+            )
             for data in selection:
                 if isinstance(data, bpy.types.Collection):
                     instance_node.children.link(data)

--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -3,6 +3,7 @@
 import bpy
 
 from ayon_blender.api import plugin, lib
+from ayon_core.lib import BoolDef
 
 
 class CreateBlendScene(plugin.BlenderCreator):
@@ -26,7 +27,8 @@ class CreateBlendScene(plugin.BlenderCreator):
         if pre_create_data.get("use_selection"):
             selection = lib.get_selection(
                 include_collections=True,
-                selected_hierarchies=True
+                selected_hierarchies=pre_create_data.get(
+                    "selected_hierarchies")
             )
             for data in selection:
                 if isinstance(data, bpy.types.Collection):
@@ -43,3 +45,12 @@ class CreateBlendScene(plugin.BlenderCreator):
             bpy.data.collections.remove(node)
 
             self._remove_instance_from_context(instance)
+
+    def get_pre_create_attr_defs(self):
+        defs = super().get_pre_create_attr_defs()
+        defs.extend([
+            BoolDef("selected_hierarchies",
+                    label="Select Hierarchies",
+                    default=False)
+        ])
+        return defs

--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -24,7 +24,10 @@ class CreateBlendScene(plugin.BlenderCreator):
                                        pre_create_data)
 
         if pre_create_data.get("use_selection"):
-            selection = lib.get_selection(include_collections=True)
+            selection = lib.get_selection(
+                include_collections=True,
+                selected_hierarchies=True
+            )
             for data in selection:
                 if isinstance(data, bpy.types.Collection):
                     instance_node.children.link(data)

--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -24,7 +24,9 @@ class CreateBlendScene(plugin.BlenderCreator):
                                        pre_create_data)
 
         if pre_create_data.get("use_selection"):
-            selection = lib.get_selection(include_collections=True)
+            selection = lib.get_selection(
+                include_collections=True, include_object_children_recursive=True
+            )
             for data in selection:
                 if isinstance(data, bpy.types.Collection):
                     instance_node.children.link(data)

--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -3,7 +3,6 @@
 import bpy
 
 from ayon_blender.api import plugin, lib
-from ayon_core.lib import BoolDef
 
 
 class CreateBlendScene(plugin.BlenderCreator):
@@ -25,11 +24,7 @@ class CreateBlendScene(plugin.BlenderCreator):
                                        pre_create_data)
 
         if pre_create_data.get("use_selection"):
-            selection = lib.get_selection(
-                include_collections=True,
-                selected_hierarchies=pre_create_data.get(
-                    "selected_hierarchies")
-            )
+            selection = lib.get_selection(include_collections=True)
             for data in selection:
                 if isinstance(data, bpy.types.Collection):
                     instance_node.children.link(data)
@@ -45,12 +40,3 @@ class CreateBlendScene(plugin.BlenderCreator):
             bpy.data.collections.remove(node)
 
             self._remove_instance_from_context(instance)
-
-    def get_pre_create_attr_defs(self):
-        defs = super().get_pre_create_attr_defs()
-        defs.extend([
-            BoolDef("selected_hierarchies",
-                    label="Select Hierarchies",
-                    default=False)
-        ])
-        return defs

--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -24,9 +24,7 @@ class CreateBlendScene(plugin.BlenderCreator):
                                        pre_create_data)
 
         if pre_create_data.get("use_selection"):
-            selection = lib.get_selection(
-                include_collections=True, include_object_children_recursive=True
-            )
+            selection = lib.get_selection(include_collections=True)
             for data in selection:
                 if isinstance(data, bpy.types.Collection):
                     instance_node.children.link(data)

--- a/client/ayon_blender/plugins/create/create_camera.py
+++ b/client/ayon_blender/plugins/create/create_camera.py
@@ -26,9 +26,9 @@ class CreateCamera(plugin.BlenderCreator):
 
         bpy.context.view_layer.objects.active = asset_group
         if pre_create_data.get("use_selection"):
-            for obj in lib.get_top_objects_selections():
-                obj.parent = asset_group
-                break
+            selections = lib.get_selection()
+            top_root = lib.get_highest_root(selections)
+            top_root.parent = asset_group
         else:
             plugin.deselect_all()
             camera = bpy.data.cameras.new(product_name)

--- a/client/ayon_blender/plugins/create/create_camera.py
+++ b/client/ayon_blender/plugins/create/create_camera.py
@@ -26,9 +26,8 @@ class CreateCamera(plugin.BlenderCreator):
 
         bpy.context.view_layer.objects.active = asset_group
         if pre_create_data.get("use_selection"):
-            selections = lib.get_selection()
-            top_root = lib.get_highest_root(selections)
-            top_root.parent = asset_group
+            for obj in lib.get_selection():
+                obj.parent = asset_group
         else:
             plugin.deselect_all()
             camera = bpy.data.cameras.new(product_name)

--- a/client/ayon_blender/plugins/create/create_camera.py
+++ b/client/ayon_blender/plugins/create/create_camera.py
@@ -26,8 +26,9 @@ class CreateCamera(plugin.BlenderCreator):
 
         bpy.context.view_layer.objects.active = asset_group
         if pre_create_data.get("use_selection"):
-            for obj in lib.get_selection():
+            for obj in lib.get_top_objects_selections():
                 obj.parent = asset_group
+                break
         else:
             plugin.deselect_all()
             camera = bpy.data.cameras.new(product_name)

--- a/client/ayon_blender/plugins/create/create_model.py
+++ b/client/ayon_blender/plugins/create/create_model.py
@@ -24,8 +24,9 @@ class CreateModel(plugin.BlenderCreator):
 
         # Add selected objects to instance
         if pre_create_data.get("use_selection"):
-            bpy.context.view_layer.objects.active = asset_group
-            for obj in lib.get_selection():
+
+            for obj in lib.get_top_objects_selections():
                 obj.parent = asset_group
+                break
 
         return asset_group

--- a/client/ayon_blender/plugins/create/create_model.py
+++ b/client/ayon_blender/plugins/create/create_model.py
@@ -1,7 +1,5 @@
 """Create a model asset."""
 
-import bpy
-
 from ayon_blender.api import plugin, lib
 
 

--- a/client/ayon_blender/plugins/create/create_model.py
+++ b/client/ayon_blender/plugins/create/create_model.py
@@ -22,9 +22,8 @@ class CreateModel(plugin.BlenderCreator):
 
         # Add selected objects to instance
         if pre_create_data.get("use_selection"):
-
-            for obj in lib.get_top_objects_selections():
-                obj.parent = asset_group
-                break
+            selections = lib.get_selection()
+            top_root = lib.get_highest_root(selections)
+            top_root.parent = asset_group
 
         return asset_group

--- a/client/ayon_blender/plugins/create/create_model.py
+++ b/client/ayon_blender/plugins/create/create_model.py
@@ -22,8 +22,7 @@ class CreateModel(plugin.BlenderCreator):
 
         # Add selected objects to instance
         if pre_create_data.get("use_selection"):
-            selections = lib.get_selection()
-            top_root = lib.get_highest_root(selections)
-            top_root.parent = asset_group
+            for obj in lib.get_selection():
+                obj.parent = asset_group
 
         return asset_group

--- a/client/ayon_blender/plugins/create/create_pointcache.py
+++ b/client/ayon_blender/plugins/create/create_pointcache.py
@@ -20,7 +20,9 @@ class CreatePointcache(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            objects = lib.get_selection()
+            objects = lib.get_selection(
+                include_object_children_recursive=True
+            )
             for obj in objects:
                 collection.objects.link(obj)
         return collection

--- a/client/ayon_blender/plugins/create/create_pointcache.py
+++ b/client/ayon_blender/plugins/create/create_pointcache.py
@@ -20,11 +20,11 @@ class CreatePointcache(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            objects = lib.get_selection()
+            objects = lib.get_selection(
+                include_object_children_recursive=True
+            )
             for obj in objects:
                 collection.objects.link(obj)
-                if obj.type == 'EMPTY':
-                    objects.extend(obj.children)
 
         return collection
 

--- a/client/ayon_blender/plugins/create/create_pointcache.py
+++ b/client/ayon_blender/plugins/create/create_pointcache.py
@@ -20,12 +20,9 @@ class CreatePointcache(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            objects = lib.get_selection(
-                include_object_children_recursive=True
-            )
+            objects = lib.get_selection()
             for obj in objects:
                 collection.objects.link(obj)
-
         return collection
 
     def get_instance_attr_defs(self):

--- a/client/ayon_blender/plugins/create/create_review.py
+++ b/client/ayon_blender/plugins/create/create_review.py
@@ -20,7 +20,9 @@ class CreateReview(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            selected = lib.get_selection()
+            selected = lib.get_selection(
+                include_object_children_recursive=True
+            )
             for obj in selected:
                 collection.objects.link(obj)
 

--- a/client/ayon_blender/plugins/create/create_usd.py
+++ b/client/ayon_blender/plugins/create/create_usd.py
@@ -20,7 +20,9 @@ class CreateUSD(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            objects = lib.get_selection()
+            objects = lib.get_selection(
+                include_object_children_recursive=True
+            )
             for obj in objects:
                 collection.objects.link(obj)
         return collection

--- a/client/ayon_blender/plugins/create/create_usd.py
+++ b/client/ayon_blender/plugins/create/create_usd.py
@@ -20,7 +20,7 @@ class CreateUSD(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            objects = lib.get_selection(include_object_children_recursive=True)
+            objects = lib.get_selection()
             for obj in objects:
                 collection.objects.link(obj)
         return collection

--- a/client/ayon_blender/plugins/create/create_usd.py
+++ b/client/ayon_blender/plugins/create/create_usd.py
@@ -1,5 +1,7 @@
 """Create a USD Export."""
 
+import bpy
+from ayon_core.lib import BoolDef
 from ayon_blender.api import plugin, lib
 
 
@@ -21,10 +23,7 @@ class CreateUSD(plugin.BlenderCreator):
         )
 
         if pre_create_data.get("use_selection"):
-            objects = lib.get_selection()
+            objects = lib.get_selection(include_object_children_recursive=True)
             for obj in objects:
                 collection.objects.link(obj)
-                if obj.type == 'EMPTY':
-                    objects.extend(obj.children)
-
         return collection

--- a/client/ayon_blender/plugins/create/create_usd.py
+++ b/client/ayon_blender/plugins/create/create_usd.py
@@ -1,7 +1,4 @@
 """Create a USD Export."""
-
-import bpy
-from ayon_core.lib import BoolDef
 from ayon_blender.api import plugin, lib
 
 

--- a/client/ayon_blender/plugins/load/load_camera_fbx.py
+++ b/client/ayon_blender/plugins/load/load_camera_fbx.py
@@ -55,7 +55,8 @@ class FbxCameraLoader(plugin.BlenderLoader):
             obj.parent = asset_group
 
         for obj in objects:
-            parent.objects.link(obj)
+            if obj not in parent.objects:
+                parent.objects.link(obj)
             collection.objects.unlink(obj)
 
         for obj in objects:

--- a/client/ayon_blender/plugins/publish/collect_instance.py
+++ b/client/ayon_blender/plugins/publish/collect_instance.py
@@ -23,7 +23,7 @@ class CollectBlenderInstanceData(plugin.BlenderInstancePlugin):
         members = [instance_node]
         if isinstance(instance_node, bpy.types.Collection):
             members.extend(instance_node.objects)
-            members.extend(instance_node.children)
+            members.extend(instance_node.children_recursive)
 
             # Special case for animation instances, include armatures
             if instance.data["productType"] == "animation":

--- a/client/ayon_blender/plugins/publish/collect_instance.py
+++ b/client/ayon_blender/plugins/publish/collect_instance.py
@@ -23,7 +23,6 @@ class CollectBlenderInstanceData(plugin.BlenderInstancePlugin):
         members = [instance_node]
         if isinstance(instance_node, bpy.types.Collection):
             members.extend(instance_node.objects)
-            members.extend(instance_node.children_recursive)
 
             # Special case for animation instances, include armatures
             if instance.data["productType"] == "animation":


### PR DESCRIPTION
## Changelog Description
This PR is to use `children_recursive` to collect all the instances members for publishing, this can ensure no missing data or empty scene being published.
Resolve https://github.com/ynput/ayon-blender/issues/127

## Additional review information
All the creators need to be tested
Loaders to be tested:
Load Cache
Load Camera Abc
Load Camera Fbx
Load fbx
Load Image Shader

## Testing notes:
1. Create any instance
2. Publish
