### PR TITLE
Create Blend Scene: Remove `maintain_selection` attribute

### DIFF
--- a/client/ayon_blender/plugins/create/create_blendScene.py
+++ b/client/ayon_blender/plugins/create/create_blendScene.py
@@ -13,8 +13,6 @@ class CreateBlendScene(plugin.BlenderCreator):
     product_type = "blendScene"
     icon = "cubes"
 
-    maintain_selection = False
-
     def create(
         self, product_name: str, instance_data: dict, pre_create_data: dict
     ):


### PR DESCRIPTION
## Changelog Description

Create Blend Scene: Remove `maintain_selection` attribute. It does nothing.

## Additional review information

This attribute only existed due to inheriting it from the legacy creators before switching to the new publisher (where it used to go through code like [this](https://github.com/ynput/ayon-core/blob/c2f3d8b114ecd93871029144bc81a77ad841758e/client/ayon_core/pipeline/create/legacy_create.py#L208)). However, I am pretty sure now it's unused.

Equivalent to:
- https://github.com/ynput/ayon-nuke/pull/127
- https://github.com/ynput/ayon-houdini/pull/282

## Testing notes:

1. Create Blend Scene should not be affected.
