### PR TITLE
Implementation of Validate No Animation

### DIFF
--- a/client/ayon_blender/plugins/publish/validate_no_animation.py
+++ b/client/ayon_blender/plugins/publish/validate_no_animation.py
@@ -4,12 +4,11 @@ import inspect
 from ayon_core.pipeline.publish import (
     ValidateContentsOrder,
     OptionalPyblishPluginMixin,
-    PublishValidationError
+    PublishValidationError,
+    RepairAction,
 )
-from ayon_blender.api.action import (
-    SelectInvalidAction,
-    RepairAction
-)
+from ayon_blender.api.action import SelectInvalidAction
+
 from ayon_blender.api import plugin
 
 
@@ -23,6 +22,7 @@ class ValidateNoAnimation(
     hosts = ["blender"]
     families = ["blendScene", "model", "rig"]
     label = "No Animation"
+    optional = True
     actions = [SelectInvalidAction, RepairAction]
 
     @classmethod

--- a/client/ayon_blender/plugins/publish/validate_no_animation.py
+++ b/client/ayon_blender/plugins/publish/validate_no_animation.py
@@ -1,0 +1,45 @@
+
+import bpy
+
+from ayon_core.pipeline.publish import (
+    ValidateContentsOrder,
+    OptionalPyblishPluginMixin,
+    PublishValidationError
+)
+import ayon_blender.api.action
+from ayon_blender.api import plugin
+
+
+class ValidateNoAnimation(
+    plugin.BlenderInstancePlugin,
+    OptionalPyblishPluginMixin
+):
+    """Ensure that meshes don't have animation data."""
+
+    order = ValidateContentsOrder
+    hosts = ["blender"]
+    families = ["blendScene", "model", "rig"]
+    label = "No Animation"
+    actions = [ayon_blender.api.action.SelectInvalidAction]
+
+    @classmethod
+    def get_invalid(cls, instance):
+        invalid = []
+        for obj in instance:
+            if isinstance(obj, bpy.types.Object):
+                if obj.animation_data and obj.animation_data.action:
+                    invalid.append(obj)
+        return invalid
+
+    def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
+        invalid = self.get_invalid(instance)
+        if invalid:
+            names = ", ".join(obj.name for obj in invalid)
+            raise PublishValidationError(
+                "Objects found in instance which have"
+                f" animation data: {names}",
+                title="Keyframes on Objects"
+            )

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -73,6 +73,11 @@ class PublishPluginsModel(BaseSettingsModel):
         description="Checks if external data having absolute file path.",
         section="General Validators"
     )
+    ValidateNoAnimation: ValidatePluginModel = SettingsField(
+        default_factory=ValidatePluginModel,
+        title="Validate No Animation",
+        description="Checks if objects have no animation data.",
+    )
     ValidateCameraZeroKeyframe: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Validate Camera Zero Keyframe",
@@ -179,6 +184,11 @@ class PublishPluginsModel(BaseSettingsModel):
 
 DEFAULT_BLENDER_PUBLISH_SETTINGS = {
     "ValidateAbsoluteDataBlockPaths": {
+        "enabled": True,
+        "optional": True,
+        "active": True
+    },
+    "ValidateNoAnimation": {
         "enabled": True,
         "optional": True,
         "active": True


### PR DESCRIPTION
## Changelog Description
This PR is to implement the optional validator to check if the objects have animation data for model, rig and blendScene product, similar to what we have to check no animation data for model product in maya.

Resolve https://github.com/ynput/ayon-blender/issues/132


## Additional review information
Tested with the objects with or without animation data.

## Testing notes:
1. Create BlendScene, Rig, Model instance by selections
2. Publish