### PR TITLE
Create Render: Do not error on legacy render instances during Collect

### DIFF
--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -203,5 +203,10 @@ class CreateRender(plugin.BlenderCreator):
     def read(self, node: bpy.types.CompositorNodeOutputFile) -> dict:
         # Read the active state from the node `mute` state.
         data = super().read(node)
-        data["active"] = not node.mute
+
+        # On super().collect_instances() it may collect legacy render instances
+        # that are not Compositor nodes but Collection objects.
+        if isinstance(node, bpy.types.CompositorNodeOutputFile):
+            data["active"] = not node.mute
+
         return data


### PR DESCRIPTION
## Changelog Description

Create Render: Do not error on legacy render instances during Collect

## Additional review information

Fix #146 

## Testing notes:
1. Resetting publisher UI with legacy render instances should work fine.