### PR TITLE
Publish: Use new workfiles API to increment current workfile.

### DIFF
--- a/client/ayon_blender/plugins/publish/increment_workfile_version.py
+++ b/client/ayon_blender/plugins/publish/increment_workfile_version.py
@@ -47,4 +47,4 @@ class IncrementWorkfileVersion(
         else:
             # Backwards compatibility before:
             # https://github.com/ynput/ayon-core/pull/1275
-            host.save_workfile(new_filepath
+            host.save_workfile(new_filepath)


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Requires latest develop `ayon-core` with this PR included: https://github.com/ynput/ayon-core/pull/1275

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
5. Publishing should also still work and increment (the old way) with older ayon-core.
