### PR TITLE
Add blender temporary scene render directory as clean up path/directory

### DIFF
--- a/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
+++ b/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
@@ -1,0 +1,25 @@
+import os
+import pyblish.api
+
+
+class CollectTemporaryFilesForCleanUp(pyblish.api.InstancePlugin):
+    """Compare rendered and expected files"""
+
+    label = "Collect Temporary Files for Clean Up"
+    order = pyblish.api.CollectorOrder - 0.1
+    targets = ["farm"]
+
+def process(self, instance):
+    for repre in instance.data["representations"]:
+        staging_dir = repre["stagingDir"]
+        temp_dir = os.path.join(staging_dir, "tmp")
+        if not os.path.exists(temp_dir):
+            self.log.debug(f"Temporary directory does not exist: {temp_dir}")
+            continue
+        self.log.debug(f"Collecting files for cleanup in directory: {temp_dir}")
+        for file in os.listdir(temp_dir):
+            file_path = os.path.join(temp_dir, file)
+            if os.path.isfile(file_path):
+                self.log.debug(f"Adding file to cleanup: {file_path}")
+                instance.context.data["cleanupFullPaths"].append(file_path)
+        instance.context.data["cleanupEmptyDirs"].append(temp_dir)

--- a/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
+++ b/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
@@ -7,6 +7,7 @@ class CollectTemporaryFilesForCleanUp(pyblish.api.InstancePlugin):
 
     label = "Collect Temporary Files for Clean Up"
     order = pyblish.api.CollectorOrder - 0.1
+    hosts = ["blender"]
     targets = ["farm"]
 
 def process(self, instance):

--- a/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
+++ b/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
@@ -14,6 +14,7 @@ class CollectTemporaryFilesCleanUp(plugin.BlenderInstancePlugin):
 
 def process(self, instance):
     temp_dir = bpy.context.scene.render.filepath
+    temp_dir = os.path.dirname(temp_dir)
     if not os.path.exists(temp_dir):
         self.log.debug(f"Temporary directory does not exist: {temp_dir}")
         return

--- a/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
+++ b/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
@@ -1,8 +1,10 @@
 import os
 import pyblish.api
+from ayon_blender.api import plugin
 import bpy
 
-class CollectTemporaryFilesCleanUp(pyblish.api.InstancePlugin):
+
+class CollectTemporaryFilesCleanUp(plugin.BlenderInstancePlugin):
     """Collect Scene Render Temporary Files for the later clean up."""
 
     label = "Collect Scene Render Temporary Files"

--- a/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
+++ b/client/ayon_blender/plugins/publish/collect_temporary_files_for_clean_up.py
@@ -1,26 +1,24 @@
 import os
 import pyblish.api
+import bpy
 
+class CollectTemporaryFilesCleanUp(pyblish.api.InstancePlugin):
+    """Collect Scene Render Temporary Files for the later clean up."""
 
-class CollectTemporaryFilesForCleanUp(pyblish.api.InstancePlugin):
-    """Compare rendered and expected files"""
-
-    label = "Collect Temporary Files for Clean Up"
+    label = "Collect Scene Render Temporary Files"
     order = pyblish.api.CollectorOrder - 0.1
     hosts = ["blender"]
     targets = ["farm"]
 
 def process(self, instance):
-    for repre in instance.data["representations"]:
-        staging_dir = repre["stagingDir"]
-        temp_dir = os.path.join(staging_dir, "tmp")
-        if not os.path.exists(temp_dir):
-            self.log.debug(f"Temporary directory does not exist: {temp_dir}")
-            continue
-        self.log.debug(f"Collecting files for cleanup in directory: {temp_dir}")
-        for file in os.listdir(temp_dir):
-            file_path = os.path.join(temp_dir, file)
-            if os.path.isfile(file_path):
-                self.log.debug(f"Adding file to cleanup: {file_path}")
-                instance.context.data["cleanupFullPaths"].append(file_path)
-        instance.context.data["cleanupEmptyDirs"].append(temp_dir)
+    temp_dir = bpy.context.scene.render.filepath
+    if not os.path.exists(temp_dir):
+        self.log.debug(f"Temporary directory does not exist: {temp_dir}")
+        return
+    self.log.debug(f"Collecting files for cleanup in directory: {temp_dir}")
+    for file in os.listdir(temp_dir):
+        file_path = os.path.join(temp_dir, file)
+        if os.path.isfile(file_path):
+            self.log.debug(f"Adding file to cleanup: {file_path}")
+            instance.context.data["cleanupFullPaths"].append(file_path)
+    instance.context.data["cleanupEmptyDirs"].append(temp_dir)


### PR DESCRIPTION
## Changelog Description
This PR is to add blender temporary scene render directory as clean up path/directory

## Additional review information
Enable `ayon+settings://core/publish/CollectRenderedFiles/remove_files` so that it can also remove along with the rendered files.
We should think about if it is much better idea to add option to `force directory clean up`  in core addon instead. This collector can be broken under some scenario 
## Testing notes:
1. Publish Render
2. Check to see if the tmp folder has been cleaned up
