### PR TITLE
Fbx loader can load with the assets outside the blender

### DIFF
--- a/client/ayon_blender/plugins/load/load_fbx.py
+++ b/client/ayon_blender/plugins/load/load_fbx.py
@@ -63,7 +63,7 @@ class FbxModelLoader(plugin.BlenderLoader):
 
         parent = bpy.context.scene.collection
 
-        imported_objects = [obj for obj in lib.get_selection()]
+        imported_objects = lib.get_selection()
         container = None
 
         for imported_object in imported_objects:


### PR DESCRIPTION
## Changelog Description
This PR is to make sure fbx loader can load the assets exported from other DCCs like Maya, where their exported assets might not have `empties` along with them

## Additional review information
n/a

## Testing notes:
1. Load anything exported from other dccs with fbx loaders in blender 
2. Load anything exported from blender with fbx loaders
3. Both should be working
