### PR TITLE
Implement backward compatibility for character truncation in 5.0

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -614,7 +614,13 @@ def strip_container_data(containers):
 @contextlib.contextmanager
 def strip_namespace(containers):
     """Strip namespace during context
+    This context manager is only valid for blender version elder than 5.0.
+    This would be deprecated after the blender 5.0.
     """
+    if get_blender_version() >= (5, 0, 0):
+        yield
+        return
+
     nodes = [
         container["node"] for container in containers
     ]

--- a/client/ayon_blender/api/plugin.py
+++ b/client/ayon_blender/api/plugin.py
@@ -30,7 +30,10 @@ from .ops import (
     MainThreadItem,
     execute_in_main_thread
 )
-from .lib import imprint
+from .lib import (
+    imprint,
+    get_blender_version
+)
 
 
 def prepare_scene_name(
@@ -44,7 +47,8 @@ def prepare_scene_name(
 
     # Blender name for a collection or object cannot be longer than 63
     # characters. If the name is longer, it will raise an error.
-    if len(name) > 63:
+    # The truncation will only happen for blender version elder than 5.0
+    if get_blender_version() < (5, 0, 0) and len(name) > 63:
         raise ValueError(f"Scene name '{name}' would be too long.")
 
     return name

--- a/client/ayon_blender/plugins/load/load_animation.py
+++ b/client/ayon_blender/plugins/load/load_animation.py
@@ -6,6 +6,7 @@ import bpy
 
 from ayon_blender.api import plugin
 from ayon_blender.api.pipeline import AYON_PROPERTY
+from ayon_blender.api.lib import get_blender_version
 
 
 class BlendAnimationLoader(plugin.BlenderLoader):
@@ -63,8 +64,9 @@ class BlendAnimationLoader(plugin.BlenderLoader):
 
         filename = bpy.path.basename(libpath)
         # Blender has a limit of 63 characters for any data name.
-        # If the filename is longer, it will be truncated.
-        if len(filename) > 63:
+        # If the filename is longer, it will be truncated for blender
+        # version elder than 5.0
+        if get_blender_version() < (5, 0, 0) and len(filename) > 63:
             filename = filename[:63]
         library = bpy.data.libraries.get(filename)
         bpy.data.libraries.remove(library)

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -10,7 +10,10 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.create import CreateContext
 from ayon_blender.api import plugin
-from ayon_blender.api.lib import imprint
+from ayon_blender.api.lib import (
+    imprint,
+    get_blender_version
+)
 from ayon_blender.api.pipeline import (
     add_to_ayon_container,
     get_ayon_property
@@ -116,8 +119,9 @@ class BlendLoader(plugin.BlenderLoader):
         # Remove the library from the blend file
         filepath = bpy.path.basename(libpath)
         # Blender has a limit of 63 characters for any data name.
-        # If the filepath is longer, it will be truncated.
-        if len(filepath) > 63:
+        # If the filename is longer, it will be truncated for blender
+        # version elder than 5.0
+        if get_blender_version() < (5, 0, 0) and len(filepath) > 63:
             filepath = filepath[:63]
         library = bpy.data.libraries.get(filepath)
         bpy.data.libraries.remove(library)

--- a/client/ayon_blender/plugins/load/load_blendscene.py
+++ b/client/ayon_blender/plugins/load/load_blendscene.py
@@ -6,7 +6,10 @@ import bpy
 
 from ayon_core.pipeline import AYON_CONTAINER_ID
 from ayon_blender.api import plugin
-from ayon_blender.api.lib import imprint
+from ayon_blender.api.lib import (
+    imprint,
+    get_blender_version
+)
 from ayon_blender.api.constants import (
     AYON_CONTAINERS,
     AYON_PROPERTY,
@@ -70,8 +73,9 @@ class BlendSceneLoader(plugin.BlenderLoader):
         # Remove the library from the blend file
         filepath = bpy.path.basename(libpath)
         # Blender has a limit of 63 characters for any data name.
-        # If the filepath is longer, it will be truncated.
-        if len(filepath) > 63:
+        # If the filepath is longer, it will be truncated for blender
+        # version elder than 5.0
+        if get_blender_version() < (5, 0, 0) and len(filepath) > 63:
             filepath = filepath[:63]
         library = bpy.data.libraries.get(filepath)
         bpy.data.libraries.remove(library)

--- a/client/ayon_blender/plugins/load/load_image_shader.py
+++ b/client/ayon_blender/plugins/load/load_image_shader.py
@@ -12,7 +12,7 @@ from ayon_core.pipeline import AYON_CONTAINER_ID
 class LoadImageShaderEditor(plugin.BlenderLoader):
     """Load a product to the Shader Editor for selected mesh in Blender."""
 
-    product_types = {"render", "image", "plate"}
+    product_types = {"render", "image", "plate", "texture"}
     representations = {"*"}
 
     label = "Load to Shader Editor"


### PR DESCRIPTION
## Changelog Description
As mentioned in https://github.com/ynput/ayon-blender/issues/118, the maximum data-block names length will be increased from 63 to 255 bytes. This PR is to add backward compatibility for some of the function for character truncation in our blender plugins.

## Additional review information
n/a


## Testing notes:
1. Load animation/blend/blendScene
2. Should be working
3. Publish BlendScene
4. Should be also working.
