### PR TITLE
Explicit publish types for load_blend_link.

### DIFF
--- a/client/ayon_blender/plugins/load/load_blend_link.py
+++ b/client/ayon_blender/plugins/load/load_blend_link.py
@@ -19,7 +19,8 @@ from ayon_blender.api.pipeline import (
 class BlendLinkLoader(plugin.BlenderLoader):
     """Link assets from a .blend file."""
 
-    product_types = {"*"}
+    product_types = {"model", "camera", "rig",
+        "action", "layout", "blendScene", "animation"}
     representations = {"blend"}
 
     label = "Link Blend"

--- a/client/ayon_blender/plugins/load/load_blend_link.py
+++ b/client/ayon_blender/plugins/load/load_blend_link.py
@@ -19,8 +19,13 @@ from ayon_blender.api.pipeline import (
 class BlendLinkLoader(plugin.BlenderLoader):
     """Link assets from a .blend file."""
 
-    product_types = {"model", "camera", "rig",
-        "action", "layout", "blendScene", "animation"}
+    product_types = {
+        "model", "camera", "rig",
+        "action", "layout", "blendScene", 
+        "animation", "workfile", "audio", 
+        "usd", "render", "image", 
+        "plate"
+    }
     representations = {"blend"}
 
     label = "Link Blend"

--- a/client/ayon_blender/plugins/load/load_blend_link.py
+++ b/client/ayon_blender/plugins/load/load_blend_link.py
@@ -22,9 +22,7 @@ class BlendLinkLoader(plugin.BlenderLoader):
     product_types = {
         "model", "camera", "rig",
         "action", "layout", "blendScene", 
-        "animation", "workfile", "audio", 
-        "usd", "render", "image", 
-        "plate"
+        "animation", "workfile"
     }
     representations = {"blend"}
 


### PR DESCRIPTION
## Changelog Description
Explicit the pubish types that needs to be loaded via `load_blend_link` this way this option does not appear for any custom client-specific product with `.blend` representation which maybe confusing and incompatible.

## Testing notes:
1. Ensure this loader still appears for AYON vanilla product
2. Ensure this loader does not appear for any custom product type with `.blend` representation.
