### PR TITLE
Validate Render Inputs: Improve validation report

### DIFF
--- a/client/ayon_blender/plugins/publish/validate_render_inputs.py
+++ b/client/ayon_blender/plugins/publish/validate_render_inputs.py
@@ -1,3 +1,5 @@
+import inspect
+
 import bpy
 
 import pyblish.api
@@ -20,12 +22,38 @@ class ValidateRenderCompositorNodeFileOutputConnected(
     hosts = ["blender"]
     families = ["render"]
     label = "Validate Render Inputs"
+    # TODO: Not sure how to select a Compositor Node through Python API so
+    #       until then, we can't select the node via the UI.
+    # actions = [SelectInvalidAction]
     optional = True
 
     def process(self, instance):
         if not self.is_active(instance.data):
             return
 
+        invalid = self.get_invalid(instance)
+
+        if invalid:
+
+            node = invalid[0].node
+            node_name = node.name
+
+            labels = []
+            for socket in invalid:
+                label = socket.name
+                labels.append(label)
+
+            raise PublishValidationError(
+                f"The Compositor File Output Node '{node_name}' has the "
+                "following unconnected image slots:\n{}".format(
+                    "\n".join(f"- {label}" for label in labels)
+                ),
+                title="Unconnected image slots",
+                description=self.get_description(),
+            )
+
+    @classmethod
+    def get_invalid(cls, instance):
         output: bpy.types.CompositorNodeOutputFile = (
             instance.data["transientData"]["instance_node"]
         )
@@ -39,10 +67,13 @@ class ValidateRenderCompositorNodeFileOutputConnected(
                 if not input_.links:
                     invalid.append(input_)
 
-        if invalid:
-            raise PublishValidationError(
-                "The Compositor File Output Node has the following "
-                "unconnected image slots: {}".format(
-                    ", ".join(str(socket) for socket in invalid)
-                )
-            )
+        return invalid
+
+    @staticmethod
+    def get_description():
+        return inspect.cleandoc("""### Unconnected image slots
+        
+        The Compositor File Output Node has unconnected input image slots.
+        Make sure to connect each of the individual slots to an input, or
+        remove the irrelevant slots if they are not needed.
+        """)


### PR DESCRIPTION
## Changelog Description

Improve the report for missing input connections on the Compositor File Output node.

## Additional review information

<img width="1297" height="715" alt="image" src="https://github.com/user-attachments/assets/03573648-f973-46eb-9833-e4bdbd05d75c" />

Fix #152

Note that I couldn't figure out quickly how to 'select' a compositor node. Only `bpy.types.Object` use `select_set` and the `bpy.types.Node` does have `select` attribute, but it's read-only. A quick google search didn't show me how to influence the node tree's selection (maybe it's UI context only?) so for now I've left the `SelectInvalidAction` commented out.

## Testing notes:
1. Create render setup with some missing inputs
2. Validation should be clear.
