### PR TITLE
Load Blend: loaded assets should be linked back to the user-defined collection during update

### DIFF
--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -250,10 +250,11 @@ class BlendLoader(plugin.BlenderLoader):
 
         imprint(asset_group, new_data)
 
-        if asset_group.name not in users_collection.objects:
-            all_objects = [asset_group] + list(asset_group.children_recursive)
-            for obj in all_objects:
-                users_collection.objects.link(obj)
+        if users_collection is not None:
+            if asset_group.name not in users_collection.objects:
+                all_objects = [asset_group] + list(asset_group.children_recursive)
+                for obj in all_objects:
+                    users_collection.objects.link(obj)
 
         # We need to update all the parent container members
         parent_containers = self.get_all_container_parents(asset_group)

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -203,9 +203,7 @@ class BlendLoader(plugin.BlenderLoader):
         old_data = dict(asset_group.get(AYON_PROPERTY))
         old_members = old_data.get("members", [])
         parent = asset_group.parent
-        users_collection = [
-            collection for collection in asset_group.users_collection
-        ]
+        users_collections = asset_group.users_collection
 
         actions = {}
         objects_with_anim = [
@@ -250,7 +248,7 @@ class BlendLoader(plugin.BlenderLoader):
 
         imprint(asset_group, new_data)
 
-        if users_collection is not None:
+        for users_collection in users_collections:
             if asset_group.name not in users_collection.objects:
                 all_objects = [asset_group] + list(asset_group.children_recursive)
                 for obj in all_objects:

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -204,7 +204,6 @@ class BlendLoader(plugin.BlenderLoader):
         old_members = old_data.get("members", [])
         parent = asset_group.parent
         users_collection = self.get_users_collection(asset_group)
-        print("users_collection", users_collection)
 
         actions = {}
         objects_with_anim = [
@@ -251,7 +250,10 @@ class BlendLoader(plugin.BlenderLoader):
 
         if users_collection is not None:
             if asset_group.name not in users_collection.objects:
-                users_collection.objects.link(asset_group)
+                all_objects = [asset_group] + list(asset_group.children_recursive)
+                for obj in all_objects:
+                    users_collection.objects.link(obj)
+
         # We need to update all the parent container members
         parent_containers = self.get_all_container_parents(asset_group)
 

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -204,6 +204,7 @@ class BlendLoader(plugin.BlenderLoader):
         old_members = old_data.get("members", [])
         parent = asset_group.parent
         users_collection = self.get_users_collection(asset_group)
+        print("users_collection", users_collection)
 
         actions = {}
         objects_with_anim = [
@@ -299,6 +300,9 @@ class BlendLoader(plugin.BlenderLoader):
         Get the users collection for a given asset group.
         """
         for collection in asset_group.users_collection:
-            if collection != bpy.context.scene.collection:
+            if (
+                collection != bpy.context.scene.collection and
+                collection.name != "AYON_CONTAINERS"
+            ):
                 return collection
         return None

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -203,7 +203,9 @@ class BlendLoader(plugin.BlenderLoader):
         old_data = dict(asset_group.get(AYON_PROPERTY))
         old_members = old_data.get("members", [])
         parent = asset_group.parent
-        users_collection = self.get_users_collection(asset_group)
+        users_collection = [
+            collection for collection in asset_group.users_collection
+        ]
 
         actions = {}
         objects_with_anim = [
@@ -248,11 +250,10 @@ class BlendLoader(plugin.BlenderLoader):
 
         imprint(asset_group, new_data)
 
-        if users_collection is not None:
-            if asset_group.name not in users_collection.objects:
-                all_objects = [asset_group] + list(asset_group.children_recursive)
-                for obj in all_objects:
-                    users_collection.objects.link(obj)
+        if asset_group.name not in users_collection.objects:
+            all_objects = [asset_group] + list(asset_group.children_recursive)
+            for obj in all_objects:
+                users_collection.objects.link(obj)
 
         # We need to update all the parent container members
         parent_containers = self.get_all_container_parents(asset_group)
@@ -296,15 +297,3 @@ class BlendLoader(plugin.BlenderLoader):
                     getattr(bpy.data, attr).remove(data)
 
         bpy.data.objects.remove(asset_group)
-
-    def get_users_collection(self, asset_group):
-        """
-        Get the users collection for a given asset group.
-        """
-        for collection in asset_group.users_collection:
-            if (
-                collection != bpy.context.scene.collection and
-                collection.name != "AYON_CONTAINERS"
-            ):
-                return collection
-        return None

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -203,6 +203,7 @@ class BlendLoader(plugin.BlenderLoader):
         old_data = dict(asset_group.get(AYON_PROPERTY))
         old_members = old_data.get("members", [])
         parent = asset_group.parent
+        users_collection = self.get_users_collection(asset_group)
 
         actions = {}
         objects_with_anim = [
@@ -247,6 +248,9 @@ class BlendLoader(plugin.BlenderLoader):
 
         imprint(asset_group, new_data)
 
+        if users_collection is not None:
+            if asset_group.name not in users_collection.objects:
+                users_collection.objects.link(asset_group)
         # We need to update all the parent container members
         parent_containers = self.get_all_container_parents(asset_group)
 
@@ -289,3 +293,12 @@ class BlendLoader(plugin.BlenderLoader):
                     getattr(bpy.data, attr).remove(data)
 
         bpy.data.objects.remove(asset_group)
+
+    def get_users_collection(self, asset_group):
+        """
+        Get the users collection for a given asset group.
+        """
+        for collection in asset_group.users_collection:
+            if collection != bpy.context.scene.collection:
+                return collection
+        return None

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -248,11 +248,14 @@ class BlendLoader(plugin.BlenderLoader):
 
         imprint(asset_group, new_data)
 
+        all_objects = [asset_group] + list(asset_group.children_recursive)
         for users_collection in users_collections:
             if asset_group.name not in users_collection.objects:
-                all_objects = [asset_group] + list(asset_group.children_recursive)
                 for obj in all_objects:
                     users_collection.objects.link(obj)
+        if bpy.context.scene.collection not in users_collections:
+            for obj in all_objects:
+                bpy.context.scene.collection.objects.unlink(obj)
 
         # We need to update all the parent container members
         parent_containers = self.get_all_container_parents(asset_group)

--- a/client/ayon_blender/plugins/load/load_blend_link.py
+++ b/client/ayon_blender/plugins/load/load_blend_link.py
@@ -105,13 +105,14 @@ class BlendLinkLoader(plugin.BlenderLoader):
         """Update the loaded asset. """
         repre = context["representation"]
         collection = container["node"]
-        library = self._get_library_from_collection(collection.children[0])
-        filepath = self.filepath_from_context(context)
-        filename = os.path.basename(filepath)
-        if library:
-            library.name = filename
-            library.filepath = filepath
-            library.reload()
+        if collection.children:
+            library = self._get_library_from_collection(collection.children[0])
+            filepath = self.filepath_from_context(context)
+            filename = os.path.basename(filepath)
+            if library:
+                library.name = filename
+                library.filepath = filepath
+                library.reload()
         # refresh UI
         bpy.context.view_layer.update()
 
@@ -124,14 +125,15 @@ class BlendLinkLoader(plugin.BlenderLoader):
         """Remove existing container from the Blender scene."""
 
         collection = container["node"]
-        library = self._get_library_from_collection(collection.children[0])
-        if library:
-            bpy.data.libraries.remove(library)
-        else:
-            # Ensure the collection is linked to the scene's master collection
-            scene_collection = bpy.context.scene.collection
-            for col in collection.children:
-                scene_collection.children.unlink(col)
+        if collection.children:
+            library = self._get_library_from_collection(collection.children[0])
+            if library:
+                bpy.data.libraries.remove(library)
+            else:
+                # Ensure the collection is linked to the scene's master collection
+                scene_collection = bpy.context.scene.collection
+                for col in collection.children:
+                    scene_collection.children.unlink(col)
         # remove the container collection
         bpy.data.collections.remove(collection)
 

--- a/client/ayon_blender/plugins/load/load_blendscene.py
+++ b/client/ayon_blender/plugins/load/load_blendscene.py
@@ -172,6 +172,7 @@ class BlendSceneLoader(plugin.BlenderLoader):
             if member_parents:
                 collection_parents[member.name] = list(member_parents)
 
+        users_collections = asset_group.users_collection
         old_data = dict(asset_group.get(AYON_PROPERTY))
 
         self.exec_remove(container)
@@ -211,6 +212,14 @@ class BlendSceneLoader(plugin.BlenderLoader):
         }
 
         imprint(asset_group, new_data)
+        all_objects = [asset_group] + list(asset_group.children_recursive)
+        for users_collection in users_collections:
+            if asset_group.name not in users_collection.objects:
+                for obj in all_objects:
+                    users_collection.objects.link(obj)
+        if bpy.context.scene.collection not in users_collections:
+            for obj in all_objects:
+                bpy.context.scene.collection.objects.unlink(obj)
 
     def exec_remove(self, container: dict) -> bool:
         """

--- a/client/ayon_blender/plugins/load/load_blendscene.py
+++ b/client/ayon_blender/plugins/load/load_blendscene.py
@@ -172,7 +172,6 @@ class BlendSceneLoader(plugin.BlenderLoader):
             if member_parents:
                 collection_parents[member.name] = list(member_parents)
 
-        users_collections = asset_group.users_collection
         old_data = dict(asset_group.get(AYON_PROPERTY))
 
         self.exec_remove(container)
@@ -212,14 +211,8 @@ class BlendSceneLoader(plugin.BlenderLoader):
         }
 
         imprint(asset_group, new_data)
-        all_objects = [asset_group] + list(asset_group.children_recursive)
-        for users_collection in users_collections:
-            if asset_group.name not in users_collection.objects:
-                for obj in all_objects:
-                    users_collection.objects.link(obj)
-        if bpy.context.scene.collection not in users_collections:
-            for obj in all_objects:
-                bpy.context.scene.collection.objects.unlink(obj)
+        if bpy.context.scene.collection not in loaded_collections:
+            bpy.context.scene.collection.children.unlink(asset_group)
 
     def exec_remove(self, container: dict) -> bool:
         """


### PR DESCRIPTION
## Changelog Description
This PR is to ensure the loaded assets would be linked back to the collection of which users manually linked the loaded asset during up-versioning and setting version.

Fixes https://github.com/ynput/ayon-blender/issues/142

## Additional review information
n/a

## Testing notes:
1. Load Model or any proudct type related to load blend
2. Add new collection and parent your loaded asset under the collection
3. Updating and Removing instances should be all good.
