### PR TITLE
Fix load user addons from paths when starting Blender.

### DIFF
--- a/client/ayon_blender/addon.py
+++ b/client/ayon_blender/addon.py
@@ -34,8 +34,9 @@ class BlenderAddon(AYONAddon, IHostAddon):
         # If `AYON_BLENDER_USE_SYSTEM_PATH` is set use `BLENDER_SYSTEM_PATH`
         # to initialize the Blender startup environment, otherwise use the
         # `BLENDER_USER_PATH`.
+        # The launch env is not applied yet, so we pass the env value
+        # from the launch environment
         use_system_path = env_value_to_bool(
-            env_key="AYON_BLENDER_USE_SYSTEM_PATH",
             value=env.get("AYON_BLENDER_USE_SYSTEM_PATH"),
         )
         if use_system_path:

--- a/client/ayon_blender/addon.py
+++ b/client/ayon_blender/addon.py
@@ -34,7 +34,10 @@ class BlenderAddon(AYONAddon, IHostAddon):
         # If `AYON_BLENDER_USE_SYSTEM_PATH` is set use `BLENDER_SYSTEM_PATH`
         # to initialize the Blender startup environment, otherwise use the
         # `BLENDER_USER_PATH`.
-        use_system_path = env_value_to_bool("AYON_BLENDER_USE_SYSTEM_PATH")
+        use_system_path = env_value_to_bool(
+            env_key="AYON_BLENDER_USE_SYSTEM_PATH",
+            value=env.get("AYON_BLENDER_USE_SYSTEM_PATH"),
+        )
         if use_system_path:
             self._configure_blender_system_paths(
                 env, implementation_script_path

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -131,7 +131,11 @@ def load_scripts(paths):
 
 
 def append_user_scripts():
-    user_scripts = os.environ.get("AYON_BLENDER_USER_SCRIPTS")
+    default_user_prefs = os.path.join(
+        bpy.utils.resource_path('USER'),
+        "scripts",
+    )
+    user_scripts = os.environ.get("AYON_BLENDER_USER_SCRIPTS") or default_user_prefs
     if not user_scripts:
         return
 

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -136,8 +136,6 @@ def append_user_scripts():
         "scripts",
     )
     user_scripts = os.environ.get("AYON_BLENDER_USER_SCRIPTS") or default_user_prefs
-    if not user_scripts:
-        return
 
     try:
         load_scripts(user_scripts.split(os.pathsep))


### PR DESCRIPTION
## Changelog Description
Fixes:
* Blender 4.4+, when using `AYON_BLENDER_USE_SYSTEM_PATH`, returned value was always `False`.
* When using `BLENDER_USER_SCRIPTS`, default user preferences were not loaded if `BLENDER_USER_SCRIPTS` was not explictely overrided.

## Testing notes:
<img width="745" height="752" alt="image" src="https://github.com/user-attachments/assets/816b4756-10ba-4f65-b8ac-1a2b5a936116" />

Blender 4.4+
1. Ensure that when `AYON_BLENDER_USE_SYSTEM_PATH` is either set to `0` or `1`, this get properly detected in the starting code.


Blender<4.4
1. Ensure default user preferences are loaded enven if `BLENDER_USER_SCRIPTS` is not defined
