### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -150,6 +150,7 @@ class CreateRender(plugin.BlenderCreator):
             return
 
         project_name = self.create_context.get_current_project_name()
+        project_entity = self.create_context.get_current_project_entity()
         folder_entity = self.create_context.get_current_folder_entity()
         task_entity = self.create_context.get_current_task_entity()
         for node in unregistered_output_nodes:
@@ -158,9 +159,11 @@ class CreateRender(plugin.BlenderCreator):
             variant = clean_name(node.name)
             product_name = self.get_product_name(
                 project_name=project_name,
+                project_entity=project_entity,
                 folder_entity=folder_entity,
                 task_entity=task_entity,
-                variant=variant
+                variant=variant,
+                host_name=self.create_context.host_name,
             )
             instance_data = self.read(node)
             instance_data.update({


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
