### PR TITLE
Load Blend Linker Versioning should be working for rig and model product

### DIFF
--- a/client/ayon_blender/plugins/load/load_blend_link.py
+++ b/client/ayon_blender/plugins/load/load_blend_link.py
@@ -142,9 +142,16 @@ class BlendLinkLoader(plugin.BlenderLoader):
     def _get_library_from_collection(
             self, collection: bpy.types.Collection) -> Union[bpy.types.Library, None]:
         """Get the library from the collection."""
+
         for child in collection.children:
             if child.library:
-                # No override library
+                return child.library
+            # With override library
+            elif child.override_library and child.override_library.reference:
+                return child.override_library.reference.library
+
+        for child in collection.objects:
+            if child.library:
                 return child.library
             # With override library
             elif child.override_library and child.override_library.reference:


### PR DESCRIPTION
## Changelog Description
This PR is to implement the fix on Load Blend Linker where the switching and updating asset does not update the library path as expected for certain product type such as rig and model.

Fix https://github.com/ynput/ayon-blender/issues/170

## Additional review information
n/a

## Testing notes:
1. Link Blend
2. Manage -> Set/Switch version
3. Should be working with all circumstances.
