### PR TITLE
load blend link load all kind of datablocks

### DIFF
--- a/client/ayon_blender/api/plugin_load.py
+++ b/client/ayon_blender/api/plugin_load.py
@@ -118,6 +118,9 @@ def load_collection(
         data_from,
         data_to,
     ):
+        for attr in dir(data_to):
+            setattr(data_to, attr, getattr(data_from, attr))
+
         # Validate source collections
         if data_from.collections:
             if lib_container_name is None:
@@ -128,9 +131,6 @@ def load_collection(
                     f"Collection '{lib_container_name}' not found in: {filepath}"
                 )
             data_to.collections = [lib_container_name]
-
-        elif data_from.objects:
-            data_to.objects = data_from.objects
 
     for coll in data_to.collections:
         if coll is not None and coll.name not in asset_container.children:


### PR DESCRIPTION
## Changelog Description
This PR is to ensure `load_blend_link` (Link Blend) can link the asset from all kinds of datablocks.
Fixes https://github.com/ynput/ayon-blender/issues/174

## Testing notes:
1. Link Blend for any assets from  "model", "camera", "rig", "action", "layout", "blendScene",  "animation", "workfile"
2. Should be all working 