### PR TITLE
Publisher UI always stays on top after review publishing

### DIFF
--- a/client/ayon_blender/plugins/publish/extract_playblast.py
+++ b/client/ayon_blender/plugins/publish/extract_playblast.py
@@ -1,6 +1,5 @@
 import os
 import json
-import contextlib
 
 import clique
 import pyblish.api


### PR DESCRIPTION
## Changelog Description
This PR is to make sure Publisher UI is always top-level widget before-after publishing review.
Resolve https://github.com/ynput/ayon-blender/issues/64

## Additional review information
n/a
## Testing notes:
1. Create Review
2. Publish
3. After finishing to extract review with the review screen closed, the publisher UI would stay at top again.
