### PR TITLE
Remove applying stylesheet globally to QApplication

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -15,7 +15,6 @@ from qtpy import QtWidgets, QtCore
 import bpy
 import bpy.utils.previews
 
-from ayon_core import style
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import (
     get_current_folder_path,
@@ -71,7 +70,6 @@ class BlenderApplication:
     @classmethod
     def _prepare_qapplication(cls, application: QtWidgets.QApplication):
         application.setQuitOnLastWindowClosed(False)
-        application.setStyleSheet(style.load_stylesheet())
         application.lastWindowClosed.connect(cls.reset)
 
     @classmethod


### PR DESCRIPTION
## Changelog Description
This PR is to remove stylesheet setup to avoid the loaded stylesheet to be applied globally to QApplication
Resolve https://github.com/ynput/ayon-blender/issues/8

## Additional review information
Please build and install addon with this branch and test.

## Testing notes:
1. Launch Blender
2. All plugins work ok
