### PR TITLE
Short labels for some plugins

### DIFF
--- a/client/ayon_blender/plugins/publish/validate_render_output_paths.py
+++ b/client/ayon_blender/plugins/publish/validate_render_output_paths.py
@@ -92,7 +92,10 @@ class ValidateSceneRenderFilePath(
     order = ValidateContentsOrder
     families = ["render"]
     hosts = ["blender"]
-    label = "Validate Scene Render Filepath"
+    label = "Validate Scene Output"
+    optional_tooltip = (
+        "Validate whether the scene-wide render filepath is set as required."
+    )
     optional = True
     actions = [RepairAction]
 


### PR DESCRIPTION
## Changelog Description
Shorten labels for the following plugins and add tool tip:
- `ValidateCompositorNodeFileOutputPaths`
- `ValidateSceneRenderFilePath`

## Testing notes:
1. start with this step
2. follow this step


Resolve #195 