### PR TITLE
Make sure the error popup dialog would stay on top

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -197,14 +197,9 @@ def _process_app_events() -> Optional[float]:
                 QtCore.Qt.WindowStaysOnTopHint |
                 QtCore.Qt.Dialog
             )
-
-            try:
-                dialog.show()
-                dialog.raise_()
-                dialog.activateWindow()
-                dialog.exec_()
-            finally:
-                dialog.deleteLater()
+            dialog.raise_()
+            dialog.activateWindow()
+            dialog.open()
 
         # Refresh Manager
         if GlobalClass.app:


### PR DESCRIPTION
## Changelog Description
This PR is to fix the issue when users load something from loader and the loader raise exceptions, and the popup dialog does not show on top of the screen, and this freezes both blender and ayon plugins.
Resolve

## Additional review information

Fix https://github.com/ynput/ayon-blender/issues/97
Fix https://github.com/ynput/ayon-blender/issues/65

## Testing notes:
1. Load something which can hit the error
2. The error popup should be always on top.
