### PR TITLE
Extract Blend: Packed Image happened only during context 

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -665,7 +665,7 @@ def strip_namespace(containers):
 
 
 @contextlib.contextmanager
-def unpacked_images(datablocks):
+def packed_images(datablocks):
     """Unpack packed images during context
     This will pack all unpacked images found in the given datablocks,
     and unpack them back when exiting the context.
@@ -746,4 +746,3 @@ def search_replace_render_paths(src: str, dest: str) -> bool:
             changes = True
 
     return changes
-

--- a/client/ayon_blender/plugins/publish/extract_blend.py
+++ b/client/ayon_blender/plugins/publish/extract_blend.py
@@ -11,7 +11,7 @@ from ayon_blender.api.lib import (
     strip_container_data,
     strip_instance_data,
     strip_namespace,
-    unpacked_images,
+    packed_images,
 )
 
 
@@ -88,7 +88,7 @@ class ExtractBlend(
             stack.enter_context(strip_container_data(containers))
             stack.enter_context(strip_instance_data(asset_group))
             stack.enter_context(strip_namespace(containers))
-            stack.enter_context(unpacked_images(data_blocks))
+            stack.enter_context(packed_images(data_blocks))
             self.log.debug("Datablocks: %s", data_blocks)
             bpy.data.libraries.write(
                 filepath, data_blocks, compress=self.compress
@@ -117,9 +117,7 @@ class ExtractBlend(
         Returns:
             set: A set of data blocks added.
         """
-        return {
-            data for data in instance
-        }
+        return set(instance)
 
 class ExtractBlendAction(ExtractBlend):
     """Extract a blend file from the current scene.


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the current image pack only happened during context for extract blend, as discussed in https://github.com/ynput/ayon-blender/issues/126
Resolve https://github.com/ynput/ayon-blender/issues/126

## Additional review information
Test with action product type to see if any issues hit. And also check the published blendScene and see if datablocks are all correctly located.

## Testing notes:
1. Create BlendScene or any product type(model, rig, action etc) 
2. Publish
3. Load the published asset back to blender and see if all the things are located in the datablocks menu.
