### PR TITLE
Extract Review: Do not select objects out of the active view layer

### DIFF
--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -125,7 +125,7 @@ def isolate_objects(window, objects):
     # errors that object can't be selected because it is not in View Layer.
     view_layer_objects = window.view_layer.objects
     for obj in objects:
-        if obj in view_layer_objects:
+        if obj.name in view_layer_objects:
             obj.select_set(True)
 
     context = create_blender_context(selected=objects, window=window)


### PR DESCRIPTION
## Changelog Description

Disregard objects out of the active view layer - as those cannot be selected

## Additional review information

Fix #212

## Testing notes:
1. Create some objects in deactivated Collections (so they are inactive) inside the main Collections.
2. Try and publish review.
3. It should work.
