### PR TITLE
Alembic Camera Loader: Object path would be always filled during versioning

### DIFF
--- a/client/ayon_blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_blender/plugins/load/load_camera_abc.py
@@ -178,7 +178,6 @@ class AbcCameraLoader(plugin.BlenderLoader):
 
         bpy.ops.cachefile.open(filepath=libpath.as_posix())
         for obj in asset_group.children:
-            asset_name = obj.name.rsplit(":", 1)[-1]
             names = [constraint.name for constraint in obj.constraints
                      if constraint.type == "TRANSFORM_CACHE"]
             file_list = [file for file in bpy.data.cache_files


### PR DESCRIPTION
## Changelog Description
This PR is to make sure object path is not empty during versioning in scene inventory.


## Additional review information
n/a

## Testing notes:
1. Load Camera (Alembic)
2. Update to the latest or set version in scene inventory
3. Object path should be filled.