### PR TITLE
Fbx Camera Loader: No duplicated objects linked to scene collections

### DIFF
--- a/client/ayon_blender/plugins/load/load_camera_fbx.py
+++ b/client/ayon_blender/plugins/load/load_camera_fbx.py
@@ -53,6 +53,13 @@ class FbxCameraLoader(plugin.BlenderLoader):
             obj.parent = asset_group
 
         for obj in objects:
+            if obj.name in parent.objects:
+                self.log.info(
+                    "Object with name '%s' already exists in the scene. "
+                    "Skipping linking to the scene collection.",
+                    obj.name,
+                )
+                continue
             parent.objects.link(obj)
             collection.objects.unlink(obj)
 


### PR DESCRIPTION
## Changelog Description
This PR is to provide a quick fix to make sure no duplicated objects linked to scene collections. 

## Additional review information
As there is no duplicated object linked to scene collections.

## Testing notes:
1. Load Camera (both abc and fbx)
2. Set version or update to the latest
3. The error should be gone
