### PR TITLE
Allow to extract blend with failed packed images

### DIFF
--- a/client/ayon_blender/plugins/publish/extract_blend.py
+++ b/client/ayon_blender/plugins/publish/extract_blend.py
@@ -88,7 +88,7 @@ class ExtractBlend(
             stack.enter_context(strip_container_data(containers))
             stack.enter_context(strip_instance_data(asset_group))
             stack.enter_context(strip_namespace(containers))
-            stack.enter_context(packed_images(data_blocks))
+            stack.enter_context(packed_images(data_blocks, logger=self.log))
             self.log.debug("Datablocks: %s", data_blocks)
             bpy.data.libraries.write(
                 filepath, data_blocks, compress=self.compress


### PR DESCRIPTION

## Changelog Description

Allow to extract blend with failed packed images (e.g. when filepath does not exist)

## Additional review information

Fix #225 

Allow failed packing to still continue with extraction.

## Testing notes:

1. Create mesh object with assigned material with a texture path that does not exist on disk.
2. Extract Blend for model, camera, blendScene or alike should continue to work but log a warning about the missing file.
