### PR TITLE
Expand to All Children: Improve label and tooltip

### DIFF
--- a/client/ayon_blender/plugins/publish/collect_instance.py
+++ b/client/ayon_blender/plugins/publish/collect_instance.py
@@ -91,11 +91,11 @@ class CollectBlenderInstanceData(plugin.BlenderInstancePlugin,
         return [
             BoolDef(
                 "collection_include_object_children_recursive",
-                label="Include Objects Hierarchy",
+                label="Expand to All Children",
                 default=True,
                 tooltip=(
-                    "If enabled, the children of objects in the collection "
-                    "will be included in the instance members.\n"
+                    "Includes all descendant children of the linked objects, "
+                    "even if not manually selected.\n"
                     "If disabled, only objects directly linked to the "
                     "collection will be included."
                 )


### PR DESCRIPTION
## Changelog Description

Change label `Include Objects Hierarchy` to `Expand to All Children` since it feels less confusing to the users + tweak the wording on the tooltip.

## Additional review information

Based on user feedback asking questions about what it does.

## Testing notes:

1. Check whether it's better.