### PR TITLE
Workfile: Use default variant instead of task name as variant name

### DIFF
--- a/client/ayon_blender/plugins/create/create_workfile.py
+++ b/client/ayon_blender/plugins/create/create_workfile.py
@@ -52,7 +52,7 @@ class CreateWorkfile(BlenderCreator, AutoCreator):
             data = {
                 "folderPath": folder_path,
                 "task": task_name,
-                "variant": task_name,
+                "variant": self.default_variant,
             }
             data.update(
                 self.get_dynamic_data(


### PR DESCRIPTION
## Changelog Description

Publish workfile with default variant instead of task name as variant.

## Additional review information

Fix #237 

## Testing notes:

You should remove this product name profile:
<img width="405" height="230" alt="image" src="https://github.com/user-attachments/assets/ca06b536-c2c0-42d5-8f26-99bb9aa5f7d8" />
```
ayon+settings://core/tools/creator/product_name_profiles/1/product_base_types
```
So that it actually uses a profile that includes the variant - otherwise you'll notice nothing.

1. Creating new workfile instance on publish in new scene should default variant to Creator's default variant (usually `Main`) instead of the current task name.
