### PR TITLE
add option to clean local renderings after publish

### DIFF
--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -215,6 +215,10 @@ class CreateRender(plugin.BlenderCreator):
                     label="Review",
                     tooltip="Mark as reviewable",
                     default=True),
+            BoolDef("clean_local_render",
+                    label="Clean Local Render",
+                    tooltip="Remove render files after publishing",
+                    default=True),
         ])
         return defs
 

--- a/client/ayon_blender/plugins/publish/extract_render.py
+++ b/client/ayon_blender/plugins/publish/extract_render.py
@@ -1,4 +1,5 @@
 import contextlib
+from pathlib import Path
 
 import bpy
 import pyblish.api
@@ -53,6 +54,14 @@ class ExtractLocalRender(
                 "Instance render target is not local, skipping local render."
             )
             return
+
+        if instance.data.get("creator_attributes", {}).get(
+            "clean_local_render"):
+            to_delete = Path(bpy.context.scene.render.filepath).as_posix().replace("/tmp/tmp", "")
+            instance.context.data["cleanupFullPaths"].append(
+                to_delete
+            )
+            self.log.debug("Adding %s to cleanup" % to_delete)
 
         frame_start: int = instance.data["frameStartHandle"]
         frame_end: int = instance.data["frameEndHandle"]


### PR DESCRIPTION
## Changelog Description
When rendering locally, there is data under tmp and then from the compositor above too.
This options removes the local renderings after a successful publish.


## Testing notes:
1. render sth with the knob enabled
2. render sth with the knob disabled

<img width="1598" height="580" alt="image" src="https://github.com/user-attachments/assets/610ba867-102a-4628-90da-95e8dafb1c14" />
