### PR TITLE
Load Cache: Do not remove materials if there are object linking to that during update

### DIFF
--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -207,6 +207,10 @@ class CacheModelLoader(plugin.BlenderLoader):
                     material = material_slot.material
                     if not material:
                         continue
+
+                    if material.users > 1:
+                        continue
+
                     bpy.data.materials.remove(material)
                 bpy.data.meshes.remove(obj.data)
             elif obj.type == 'EMPTY':

--- a/client/ayon_blender/plugins/load/load_cache.py
+++ b/client/ayon_blender/plugins/load/load_cache.py
@@ -200,18 +200,6 @@ class CacheModelLoader(plugin.BlenderLoader):
 
         for obj in objects:
             if obj.type == 'MESH':
-                # QUESTION: Are we sure we want to remove the materials when
-                #  removing the mesh? What if the material is shared with
-                #  other objects?
-                for material_slot in list(obj.material_slots):
-                    material = material_slot.material
-                    if not material:
-                        continue
-
-                    if material.users > 1:
-                        continue
-
-                    bpy.data.materials.remove(material)
                 bpy.data.meshes.remove(obj.data)
             elif obj.type == 'EMPTY':
                 objects.extend(obj.children)


### PR DESCRIPTION
## Changelog Description
This PR is to make sure cache loader not removing material if there are any other objects linking to that during update
Fixes: https://github.com/ynput/ayon-blender/issues/282

## Additional review information
n/a

## Testing notes:
1. Load Cache with material or assign some material to the cache object
2. Make sure the assigned material also assigned to another objects(e.g. object B)
3. Updating the loaded cache asset
4. The material still preserves in the another objects(e.g. object B)
