### PR TITLE
Blender 5.0: Media type setting set to the correct attribute for multilayer exr setting

### DIFF
--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -58,8 +58,11 @@ def set_render_format(ext: str, multilayer: bool):
     bpy.context.scene.render.use_file_extension = True
     image_settings = bpy.context.scene.render.image_settings
 
-    if multilayer and lib.get_blender_version() >= (5, 0, 0):
-        image_settings.media_type = "MULTI_LAYER_IMAGE"
+    if lib.get_blender_version() >= (5, 0, 0):
+        if multilayer:
+            image_settings.media_type = "MULTI_LAYER_IMAGE"
+        else:
+            image_settings.media_type = "IMAGE"
 
     if ext == "exr":
         file_format = "OPEN_EXR_MULTILAYER" if multilayer else "OPEN_EXR"


### PR DESCRIPTION
## Changelog Description
This PR is to ensure media type setting set to the correct attributes so that it won't hit the enum error as stated in https://github.com/ynput/ayon-blender/issues/285

## Additional review information
Put it into draft first and no guarantee there is some issue hit when passing the attributes to collector.

## Testing notes:
1. Create render instance by rendersetup and make sure `ayon+settings://blender/RenderSettings/multilayer_exr` on and image format is `OpenEXR`
2. Publish should be successful
3. Create render instance by rendersetup again but this time  `ayon+settings://blender/RenderSettings/multilayer_exr` off and image format is still `OpenEXR`.
4. Publish should be also successful
