### PR TITLE
Fix UI refresh interval on linux

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -38,7 +38,7 @@ PREVIEW_COLLECTIONS: Dict = dict()
 # This seems like a good value to keep the Qt app responsive and doesn't slow
 # down Blender. At least on macOS I the interface of Blender gets very laggy if
 # you make it smaller.
-TIMER_INTERVAL: float = 0.01 if platform.system() == "Windows" else 0.1
+TIMER_INTERVAL: float = 0.1 if platform.system() == "Darwin" else 0.01
 
 
 def execute_function_in_main_thread(f):

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -34,11 +34,7 @@ from . import render_lib
 
 
 PREVIEW_COLLECTIONS: Dict = dict()
-
-# This seems like a good value to keep the Qt app responsive and doesn't slow
-# down Blender. At least on macOS I the interface of Blender gets very laggy if
-# you make it smaller.
-TIMER_INTERVAL: float = 0.1 if platform.system() == "Darwin" else 0.01
+TIMER_INTERVAL: float = 0.01
 
 
 def execute_function_in_main_thread(f):


### PR DESCRIPTION
## Changelog Description
Linux Qt UI was very sluggish. The app handler refresh interval was set too large. This was probably set up for an issue on MacOS and unnecessarily applied to Linux (probably never tested). Flipping a switch took multiple seconds since animation playback was so slow.

## Additional review information
Changed the global variable `TIMER_INTERVAL` to be 0.01 with Darwin to be the exception at 0.1. The "normal" interval was the exception for Windows instead.

## Testing notes:
Tested and verified on these Linux system configurations:
- AlmaLinux9, NVIDIA, Xorg, Blender 4.5 + 5.1
- Fedora 43, NVIDIA, Wayland, Blender 4.5 + 5.1
- Fedora 43, Intel Arc, Wayland, Blender 4.5 + 5.1
