### PR TITLE
Get AYON property data return dictionary data type 

### DIFF
--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -519,7 +519,7 @@ def _discover_gui() -> Optional[Callable]:
     return None
 
 
-def get_ayon_property(node):
+def get_ayon_property(node) -> Dict:
     property = node.get(AYON_PROPERTY)
     if not property:
         # Backwards compatibility: Update legacy
@@ -532,7 +532,7 @@ def get_ayon_property(node):
             )
             node[AYON_PROPERTY] = property
             del node[AVALON_PROPERTY]
-    return property
+    return property.to_dict() if property else {}
 
 
 def convert_avalon_instances():


### PR DESCRIPTION
## Changelog Description
This PR is to fix the blender crash when ayon property data return irrelevant data type which is not readable for python.
Fixes: https://github.com/ynput/ayon-blender/issues/293
## Additional review information
Tested with load placeholder, load blendscene, load blend with new ayon data.
Tested with old avalon data in the publisher UI and placeholder and loaders as mentioned above
Tested in Blender 4.x and 5.x 

## Testing notes:
1. Use old workfile with avalon data
2. Open publisher or any UI
3. Should not crash blender and show up all the data in Publisher
4. Use workfile with ayon data
5. Should be also not crashing the publisher or any UI
