### PR TITLE
Create Render: Support for selected view layers

### DIFF
--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -460,6 +460,24 @@ def create_render_node_tree(
 
     return output
 
+def get_selected_render_layer_nodes(
+        node_tree: "bpy.types.NodeTree"
+) -> list["bpy.types.CompositorNodeRLayers"]:
+    """Get the selected render layer nodes from the given node tree.
+
+    Args:
+        node_tree (bpy.types.NodeTree): The node tree to search for selected render layer nodes.
+
+    Returns:
+        list[bpy.types.CompositorNodeRLayers]: A list of selected render layer nodes.
+
+    """
+    selected_nodes = []
+    for node in node_tree.nodes:
+        if node.bl_idname == "CompositorNodeRLayers" and node.select:
+            selected_nodes.append(node)
+    return selected_nodes
+
 
 def prepare_rendering(
     variant_name: str,
@@ -510,8 +528,8 @@ def prepare_rendering(
     # Use selected renderlayer nodes, or assume we want a renderlayer node for
     # each view layer so we retrieve all of them.
     node_tree = lib.get_scene_node_tree(ensure_exists=True)
-    selected_renderlayer_nodes = []
-    
+    selected_renderlayer_nodes = get_selected_render_layer_nodes(node_tree)
+
     # Check if node_tree is available before accessing nodes
     if node_tree is not None:
         for node in node_tree.nodes:

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -361,8 +361,9 @@ def create_render_node_tree(
         output.format.media_type = (
             "MULTI_LAYER_IMAGE" if multi_exr else "IMAGE"
         )
-        # OPEN_EXR_MULTILAYER is not valid for the compositor output node;
-        # multilayer is handled via media_type instead.
+        # OPEN_EXR_MULTILAYER only valid when multi_exr is True
+        # For non multilayer exr and exr format is used, file format
+        # should be OPEN_EXR, otherwise it should follow the scene file format
         if multi_exr:
             file_format = "OPEN_EXR_MULTILAYER"
         elif ext == "exr":
@@ -474,7 +475,7 @@ def get_selected_render_layer_nodes(
         node_tree: "bpy.types.NodeTree",
         selected_all: bool = False,
         selected_view_layers: Optional[list[str]] = None
-) -> list["bpy.types.CompositorNodeRLayers"]:
+) -> set["bpy.types.CompositorNodeRLayers"]:
     """Get the selected render layer nodes from the given node tree.
 
     Args:
@@ -486,10 +487,10 @@ def get_selected_render_layer_nodes(
         only nodes whose view-layer names are included.
 
     Returns:
-        list[bpy.types.CompositorNodeRLayers]: A list of selected render layer nodes.
+        set[bpy.types.CompositorNodeRLayers]: A set of selected render layer nodes.
 
     """
-    selected_nodes = []
+    selected_nodes = set()
     for node in node_tree.nodes:
         if node.bl_idname == "CompositorNodeRLayers" and (selected_all or node.select):
             if (
@@ -497,7 +498,7 @@ def get_selected_render_layer_nodes(
                 and not has_selected_view_layers(selected_view_layers, node)
             ):
                 continue
-            selected_nodes.append(node)
+            selected_nodes.add(node)
 
     return selected_nodes
 
@@ -694,12 +695,14 @@ def has_selected_view_layers(
 
     Args:
         selected_view_layers (Optional[list[str]]): selected view layers to consider 
-            for inclusion. If None, all view layers are included.
+            for inclusion. If None or empty, the function returns False; use this 
+            function only when you know selected_view_layers is non-empty.
         node (bpy.types.CompositorNodeRLayers): the compositor node to check against 
             the selected view layers.
 
     Returns:
-        bool: True if the node's layer is in the selected view layers, False otherwise.
+        bool: True if selected_view_layers is non-empty and the node's layer is in it,
+            False otherwise (including when selected_view_layers is None or empty).
     """
     if not selected_view_layers:
         return False

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -461,12 +461,15 @@ def create_render_node_tree(
     return output
 
 def get_selected_render_layer_nodes(
-        node_tree: "bpy.types.NodeTree"
+        node_tree: "bpy.types.NodeTree",
+        selected_all: bool = False,
 ) -> list["bpy.types.CompositorNodeRLayers"]:
     """Get the selected render layer nodes from the given node tree.
 
     Args:
         node_tree (bpy.types.NodeTree): The node tree to search for selected render layer nodes.
+        selected_all (bool): If True, all render layer nodes are returned regardless of selection.
+            If False, only selected nodes are returned.
 
     Returns:
         list[bpy.types.CompositorNodeRLayers]: A list of selected render layer nodes.
@@ -474,7 +477,7 @@ def get_selected_render_layer_nodes(
     """
     selected_nodes = []
     for node in node_tree.nodes:
-        if node.bl_idname == "CompositorNodeRLayers" and node.select:
+        if node.bl_idname == "CompositorNodeRLayers" and (selected_all or node.select):
             selected_nodes.append(node)
     return selected_nodes
 

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -467,7 +467,25 @@ def prepare_rendering(
     *,
     selected_view_layers: Optional[list[str]] = None
 ) -> "bpy.types.CompositorNodeOutputFile":
-    """Initialize render setup using render settings from project settings."""
+    """Initialize render setup using render settings from project settings.
+
+    Args:
+        variant_name (str): Render variant name used when generating the output
+            node tree and output paths.
+        project_settings (Optional[dict]): Project settings dictionary. If ``None``, the
+            settings are loaded for the current project.
+        selected_view_layers (Optional[list[str]]): Optional list of Blender view-layer
+            names to limit which render layer nodes are used or created. Use ``None``
+            to apply the setup to all available view layers. An empty list is
+            currently treated the same as ``None`` because it is falsy, so it
+            also results in all view layers being considered rather than no
+            layers.
+
+    Returns:
+        bpy.types.CompositorNodeOutputFile: The compositor file output node created
+            for the render setup.
+
+    """
     assert bpy.data.filepath, "Workfile not saved. Please save the file first."
 
     if project_settings is None:
@@ -571,7 +589,22 @@ def get_or_create_render_layer_nodes(
     view_layers: list["bpy.types.ViewLayer"],
     selected_view_layers: Optional[list[str]] = None
 ) -> set[bpy.types.CompositorNodeRLayers]:
-    """Get existing render layer nodes or create new ones."""
+    """Get existing render layer nodes or create new ones.
+    By default, this reuses or creates compositor render layer nodes for all
+    provided ``view_layers``. When ``selected_view_layers`` is provided, only
+    nodes whose view-layer names are in that selection are reused or created.
+
+    Args:
+        view_layers (list[bpy.types.ViewLayer]): Available view layers to
+            consider.
+        selected_view_layers (Optional[list[str]]): Specific view-layer names
+            to include. If None, all provided view layers are included.
+
+    Returns:
+        set[bpy.types.CompositorNodeRLayers]: Existing or newly created render
+            layer nodes matching the requested view layers.
+
+    """
     tree = lib.get_scene_node_tree(ensure_exists=True)
 
     view_layer_names: set[str] = {
@@ -636,6 +669,8 @@ def has_selected_view_layers(
     Returns:
         bool: True if the node's layer is in the selected view layers, False otherwise.
     """
+    if not selected_view_layers:
+        return False
     for view_layer_name in selected_view_layers:
         if view_layer_name == node.layer:
             return True

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -354,13 +354,23 @@ def create_render_node_tree(
     # Multi-exr
     multi_exr: bool = ext == "exr" and multilayer
     blender_version = lib.get_blender_version()
+    # By default, match output format from scene file format
+    image_settings = bpy.context.scene.render.image_settings
+    file_format = image_settings.file_format
     if blender_version >= (5, 0, 0):
         output.format.media_type = (
             "MULTI_LAYER_IMAGE" if multi_exr else "IMAGE"
         )
-    # By default, match output format from scene file format
-    image_settings = bpy.context.scene.render.image_settings
-    output.format.file_format = image_settings.file_format
+        # OPEN_EXR_MULTILAYER is not valid for the compositor output node;
+        # multilayer is handled via media_type instead.
+        if multi_exr:
+            file_format = "OPEN_EXR_MULTILAYER"
+        elif ext == "exr":
+            file_format = "OPEN_EXR"
+        else:
+            file_format = image_settings.file_format
+
+    output.format.file_format = file_format
 
     # Define the base path for the File Output node.
     base_path = get_base_render_output_path(

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -462,7 +462,9 @@ def create_render_node_tree(
 
 
 def prepare_rendering(
-    variant_name: str, project_settings: Optional[dict] = None
+    variant_name: str,
+    selected_view_layers: Optional[list[str]] = None,
+    project_settings: Optional[dict] = None
 ) -> "bpy.types.CompositorNodeOutputFile":
     """Initialize render setup using render settings from project settings."""
     assert bpy.data.filepath, "Workfile not saved. Please save the file first."
@@ -495,12 +497,17 @@ def prepare_rendering(
     if node_tree is not None:
         for node in node_tree.nodes:
             if node.bl_idname == "CompositorNodeRLayers" and node.select:
+                if has_selected_view_layers(selected_view_layers, node):
+                        continue
                 selected_renderlayer_nodes.append(node)
 
     if selected_renderlayer_nodes:
         render_layer_nodes = selected_renderlayer_nodes
     else:
-        render_layer_nodes = get_or_create_render_layer_nodes(view_layers)
+        render_layer_nodes = get_or_create_render_layer_nodes(
+            view_layers,
+            selected_view_layers=selected_view_layers
+        )
 
     # Generate Compositing nodes
     output_node = create_render_node_tree(
@@ -558,6 +565,7 @@ def set_tmp_scene_render_output_path(project_settings: dict):
 
 def get_or_create_render_layer_nodes(
     view_layers: list["bpy.types.ViewLayer"],
+    selected_view_layers: Optional[list[str]] = None
 ) -> set[bpy.types.CompositorNodeRLayers]:
     """Get existing render layer nodes or create new ones."""
     tree = lib.get_scene_node_tree(ensure_exists=True)
@@ -571,6 +579,9 @@ def get_or_create_render_layer_nodes(
     found_view_layer_names: set[str] = set()
     for node in tree.nodes:
         if node.bl_idname != "CompositorNodeRLayers":
+            continue
+
+        if has_selected_view_layers(selected_view_layers, node):
             continue
 
         # Skip if already found a render layer node for this view layer.
@@ -588,9 +599,38 @@ def get_or_create_render_layer_nodes(
     missing_view_layer_names: set[str] = (
         view_layer_names - found_view_layer_names
     )
+    if selected_view_layers:
+         missing_view_layer_names = missing_view_layer_names.intersection(
+            set(selected_view_layers)
+        )
+
     for view_layer_name in missing_view_layer_names:
         render_layer_node = tree.nodes.new("CompositorNodeRLayers")
         render_layer_node.layer = view_layer_name
         render_layer_nodes.add(render_layer_node)
 
     return render_layer_nodes
+
+
+def has_selected_view_layers(
+        selected_view_layers: Optional[list[str]],
+        node: bpy.types.CompositorNodeRLayers
+) -> bool:
+    """Check if the given compositor view layer node has a view
+    layer that is in the selected view layers.
+
+    Args:
+        selected_view_layers (Optional[list[str]]): selected view layers to consider 
+            for inclusion. If None, all view layers are included.
+        node (bpy.types.CompositorNodeRLayers): the compositor node to check against 
+            the selected view layers.
+
+    Returns:
+        bool: True if the node's layer is in the selected view layers, False otherwise.
+    """
+    if not selected_view_layers:
+        return False
+    for view_layer_name in selected_view_layers:
+        if view_layer_name == node.layer:
+            return True
+    return False

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -497,8 +497,11 @@ def prepare_rendering(
     if node_tree is not None:
         for node in node_tree.nodes:
             if node.bl_idname == "CompositorNodeRLayers" and node.select:
-                if has_selected_view_layers(selected_view_layers, node):
-                        continue
+                if (
+                    selected_view_layers
+                    and not has_selected_view_layers(selected_view_layers, node)
+                ):
+                    continue
                 selected_renderlayer_nodes.append(node)
 
     if selected_renderlayer_nodes:

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -636,8 +636,6 @@ def has_selected_view_layers(
     Returns:
         bool: True if the node's layer is in the selected view layers, False otherwise.
     """
-    if not selected_view_layers:
-        return False
     for view_layer_name in selected_view_layers:
         if view_layer_name == node.layer:
             return True

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -473,6 +473,7 @@ def create_render_node_tree(
 def get_selected_render_layer_nodes(
         node_tree: "bpy.types.NodeTree",
         selected_all: bool = False,
+        selected_view_layers: Optional[list[str]] = None
 ) -> list["bpy.types.CompositorNodeRLayers"]:
     """Get the selected render layer nodes from the given node tree.
 
@@ -480,6 +481,9 @@ def get_selected_render_layer_nodes(
         node_tree (bpy.types.NodeTree): The node tree to search for selected render layer nodes.
         selected_all (bool): If True, all render layer nodes are returned regardless of selection.
             If False, only selected nodes are returned.
+        selected_view_layers (Optional[list[str]]): Optional list of Blender view-layer names
+        to limit which render layer nodes are included. If provided,
+        only nodes whose view-layer names are included.
 
     Returns:
         list[bpy.types.CompositorNodeRLayers]: A list of selected render layer nodes.
@@ -488,7 +492,13 @@ def get_selected_render_layer_nodes(
     selected_nodes = []
     for node in node_tree.nodes:
         if node.bl_idname == "CompositorNodeRLayers" and (selected_all or node.select):
+            if (
+                selected_view_layers
+                and not has_selected_view_layers(selected_view_layers, node)
+            ):
+                continue
             selected_nodes.append(node)
+
     return selected_nodes
 
 
@@ -541,18 +551,9 @@ def prepare_rendering(
     # Use selected renderlayer nodes, or assume we want a renderlayer node for
     # each view layer so we retrieve all of them.
     node_tree = lib.get_scene_node_tree(ensure_exists=True)
-    selected_renderlayer_nodes = get_selected_render_layer_nodes(node_tree)
-
-    # Check if node_tree is available before accessing nodes
-    if node_tree is not None:
-        for node in node_tree.nodes:
-            if node.bl_idname == "CompositorNodeRLayers" and node.select:
-                if (
-                    selected_view_layers
-                    and not has_selected_view_layers(selected_view_layers, node)
-                ):
-                    continue
-                selected_renderlayer_nodes.append(node)
+    selected_renderlayer_nodes = get_selected_render_layer_nodes(
+        node_tree, selected_view_layers=selected_view_layers
+    )
 
     if selected_renderlayer_nodes:
         render_layer_nodes = selected_renderlayer_nodes

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -463,8 +463,9 @@ def create_render_node_tree(
 
 def prepare_rendering(
     variant_name: str,
-    selected_view_layers: Optional[list[str]] = None,
-    project_settings: Optional[dict] = None
+    project_settings: Optional[dict] = None,
+    *,
+    selected_view_layers: Optional[list[str]] = None
 ) -> "bpy.types.CompositorNodeOutputFile":
     """Initialize render setup using render settings from project settings."""
     assert bpy.data.filepath, "Workfile not saved. Please save the file first."

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -584,7 +584,11 @@ def get_or_create_render_layer_nodes(
         if node.bl_idname != "CompositorNodeRLayers":
             continue
 
-        if has_selected_view_layers(selected_view_layers, node):
+        # When a selection is provided, include only nodes whose layer is
+        # selected so existing selected nodes are reused instead of duplicated.
+        if selected_view_layers and not has_selected_view_layers(
+            selected_view_layers, node
+        ):
             continue
 
         # Skip if already found a render layer node for this view layer.

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -608,7 +608,7 @@ def get_or_create_render_layer_nodes(
         view_layer_names - found_view_layer_names
     )
     if selected_view_layers:
-         missing_view_layer_names = missing_view_layer_names.intersection(
+        missing_view_layer_names = missing_view_layer_names.intersection(
             set(selected_view_layers)
         )
 

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -553,7 +553,11 @@ def prepare_rendering(
     # each view layer so we retrieve all of them.
     node_tree = lib.get_scene_node_tree(ensure_exists=True)
     selected_renderlayer_nodes = get_selected_render_layer_nodes(
-        node_tree, selected_view_layers=selected_view_layers
+        node_tree,
+        # If no specific view layers are selected,
+        # consider all nodes as selected
+        selected_all=not selected_view_layers,
+        selected_view_layers=selected_view_layers
     )
 
     if selected_renderlayer_nodes:

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -651,13 +651,6 @@ def get_or_create_render_layer_nodes(
         if node.bl_idname != "CompositorNodeRLayers":
             continue
 
-        # When a selection is provided, include only nodes whose layer is
-        # selected so existing selected nodes are reused instead of duplicated.
-        if selected_view_layers and not has_selected_view_layers(
-            selected_view_layers, node
-        ):
-            continue
-
         # Skip if already found a render layer node for this view layer.
         if node.layer in found_view_layer_names:
             continue

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -721,9 +721,8 @@ def get_selected_view_layers(
     Returns:
         list[bpy.types.ViewLayer]: List of selected view layers.
     """
-    if selected_view_layers is None:
+    if not selected_view_layers:
         return bpy.context.scene.view_layers
-
     selected_view_layers_list = []
     for view_layer in bpy.context.scene.view_layers:
         if view_layer.name in selected_view_layers:

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -546,7 +546,7 @@ def prepare_rendering(
     # Set scene render settings
     set_render_format(ext, multilayer)
     bpy.context.scene.render.engine = renderer
-    view_layers = bpy.context.scene.view_layers
+    view_layers = get_selected_view_layers(selected_view_layers=selected_view_layers)
     set_render_passes(project_settings, renderer, view_layers)
 
     # Use selected renderlayer nodes, or assume we want a renderlayer node for
@@ -710,3 +710,26 @@ def has_selected_view_layers(
         if view_layer_name == node.layer:
             return True
     return False
+
+
+def get_selected_view_layers(
+    selected_view_layers: Optional[list[str]] = None
+) -> list["bpy.types.ViewLayer"]:
+    """Get the selected view layers based on the provided names.
+
+    Args:
+        selected_view_layers (Optional[list[str]]): List of view layer names to select.
+            If None, all view layers are returned.
+
+    Returns:
+        list[bpy.types.ViewLayer]: List of selected view layers.
+    """
+    if selected_view_layers is None:
+        return bpy.context.scene.view_layers
+
+    selected_view_layers_list = []
+    for view_layer in bpy.context.scene.view_layers:
+        if view_layer.name in selected_view_layers:
+            selected_view_layers_list.append(view_layer)
+
+    return selected_view_layers_list

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -73,6 +73,22 @@ class CreateRender(plugin.BlenderCreator):
                 variant_name=variant,
                 selected_view_layers=view_layers
             )
+
+            project_name = self.create_context.get_current_project_name()
+            project_entity = self.create_context.get_current_project_entity()
+            folder_entity = self.create_context.get_current_folder_entity()
+            task_entity = self.create_context.get_current_task_entity()
+
+            variant = clean_name(node.name)
+            product_name = self.get_product_name(
+                project_name=project_name,
+                project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
+                host_name=self.create_context.host_name,
+                product_type=self.product_base_type,
+            )
         else:
             # Create a Compositor node
             node: bpy.types.CompositorNodeOutputFile = tree.nodes.new(
@@ -96,29 +112,14 @@ class CreateRender(plugin.BlenderCreator):
             else:
                 node.base_path = base_path
 
-            node.name = variant
-            node.label = variant
-
-        project_name = self.create_context.get_current_project_name()
-        project_entity = self.create_context.get_current_project_entity()
-        folder_entity = self.create_context.get_current_folder_entity()
-        task_entity = self.create_context.get_current_task_entity()
+        node.name = variant
+        node.label = variant
 
         self.set_instance_data(product_name, instance_data)
         product_type = instance_data.get("productType")
         if not product_type:
             product_type = self.product_base_type
 
-        variant = clean_name(node.name)
-        product_name = self.get_product_name(
-            project_name=project_name,
-            project_entity=project_entity,
-            folder_entity=folder_entity,
-            task_entity=task_entity,
-            variant=variant,
-            host_name=self.create_context.host_name,
-            product_type=product_type,
-        )
         instance = CreatedInstance(
             product_base_type=self.product_base_type,
             product_type=product_type,

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -78,35 +78,15 @@ class CreateRender(plugin.BlenderCreator):
             project_settings = (
                 self.create_context.get_current_project_settings()
             )
-            selected_renderlayer_nodes = render_lib.get_selected_render_layer_nodes(tree)
-            if selected_renderlayer_nodes:
-                node = render_lib.create_render_node_tree(
-                    variant,
-                    selected_renderlayer_nodes,
-                    project_settings
-                )
-            else:
-                # Create a Compositor node
-                node: bpy.types.CompositorNodeOutputFile = tree.nodes.new(
-                    "CompositorNodeOutputFile"
-                )
-                base_path = render_lib.get_base_render_output_path(
-                    variant_name=variant,
-                    # For now enforce multi-exr here since we are not connecting
-                    # any inputs and it at least ensures a full path is set.
-                    multi_exr=True,
-                    project_settings=project_settings,
-                )
-                node.format.file_format = "OPEN_EXR_MULTILAYER"
-                if BLENDER_VERSION >= (5, 0, 0):
-                    directory, filename = os.path.split(base_path)
-                    node.directory = directory
-                    node.file_name = filename
-                else:
-                    node.base_path = base_path
-
-                node.name = variant
-                node.label = variant
+            view_layer_nodes = render_lib.get_selected_render_layer_nodes(
+                tree,
+                selected_all=True
+            )
+            node = render_lib.create_render_node_tree(
+                variant,
+                view_layer_nodes,
+                project_settings
+            )
 
         self.set_instance_data(product_name, instance_data)
 

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -1,5 +1,4 @@
 """Create render."""
-import os
 import re
 
 import bpy

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -96,13 +96,29 @@ class CreateRender(plugin.BlenderCreator):
             else:
                 node.base_path = base_path
 
-        node.name = variant
-        node.label = variant
+            node.name = variant
+            node.label = variant
+
+        project_name = self.create_context.get_current_project_name()
+        project_entity = self.create_context.get_current_project_entity()
+        folder_entity = self.create_context.get_current_folder_entity()
+        task_entity = self.create_context.get_current_task_entity()
 
         self.set_instance_data(product_name, instance_data)
         product_type = instance_data.get("productType")
         if not product_type:
             product_type = self.product_base_type
+
+        variant = clean_name(node.name)
+        product_name = self.get_product_name(
+            project_name=project_name,
+            project_entity=project_entity,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=variant,
+            host_name=self.create_context.host_name,
+            product_type=product_type,
+        )
         instance = CreatedInstance(
             product_base_type=self.product_base_type,
             product_type=product_type,

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -90,30 +90,39 @@ class CreateRender(plugin.BlenderCreator):
                 product_type=self.product_base_type,
             )
         else:
-            # Create a Compositor node
-            node: bpy.types.CompositorNodeOutputFile = tree.nodes.new(
-                "CompositorNodeOutputFile"
-            )
             project_settings = (
                 self.create_context.get_current_project_settings()
             )
-            base_path = render_lib.get_base_render_output_path(
-                variant_name=variant,
-                # For now enforce multi-exr here since we are not connecting
-                # any inputs and it at least ensures a full path is set.
-                multi_exr=True,
-                project_settings=project_settings,
-            )
-            node.format.file_format = "OPEN_EXR_MULTILAYER"
-            if BLENDER_VERSION >= (5, 0, 0):
-                directory, filename = os.path.split(base_path)
-                node.directory = directory
-                node.file_name = filename
+            selected_renderlayer_nodes = render_lib.get_selected_render_layer_nodes(tree)
+            if selected_renderlayer_nodes:
+                node = render_lib.create_render_node_tree(
+                    variant,
+                    selected_renderlayer_nodes,
+                    project_settings
+                )
             else:
-                node.base_path = base_path
+                # Create a Compositor node
+                node: bpy.types.CompositorNodeOutputFile = tree.nodes.new(
+                    "CompositorNodeOutputFile"
+                )
+                base_path = render_lib.get_base_render_output_path(
+                    variant_name=variant,
+                    # For now enforce multi-exr here since we are not connecting
+                    # any inputs and it at least ensures a full path is set.
+                    multi_exr=True,
+                    project_settings=project_settings,
+                )
+                node.format.file_format = "OPEN_EXR_MULTILAYER"
+                if BLENDER_VERSION >= (5, 0, 0):
+                    directory, filename = os.path.split(base_path)
+                    node.directory = directory
+                    node.file_name = filename
+                else:
+                    node.base_path = base_path
 
-        node.name = variant
-        node.label = variant
+                node.name = variant
+                node.label = variant
+
 
         self.set_instance_data(product_name, instance_data)
         product_type = instance_data.get("productType")

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -61,13 +61,13 @@ class CreateRender(plugin.BlenderCreator):
         tree = lib.get_scene_node_tree(ensure_exists=True)
 
         variant: str = instance_data.get("variant", self.default_variant)
+        view_layers: Optional[list[str]] = pre_create_data.get("view_layers")
 
         if pre_create_data.get("create_render_setup", False):
             # TODO: Prepare rendering setup should always generate a new
             #  setup, and return the relevant compositor node instead of
             #  guessing afterwards
             # add options to select renderlayers
-            view_layers: Optional[list[str]] = pre_create_data.get("view_layers")
             node = render_lib.prepare_rendering(
                 variant_name=variant,
                 selected_view_layers=view_layers
@@ -79,7 +79,8 @@ class CreateRender(plugin.BlenderCreator):
             )
             view_layer_nodes = render_lib.get_selected_render_layer_nodes(
                 tree,
-                selected_all=True
+                selected_all=True,
+                selected_view_layers=view_layers
             )
             node = render_lib.create_render_node_tree(
                 variant,

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -67,7 +67,12 @@ class CreateRender(plugin.BlenderCreator):
             # TODO: Prepare rendering setup should always generate a new
             #  setup, and return the relevant compositor node instead of
             #  guessing afterwards
-            node = render_lib.prepare_rendering(variant_name=variant)
+            # add options to select renderlayers
+            view_layers: Optional[list[str]] = pre_create_data.get("view_layers")
+            node = render_lib.prepare_rendering(
+                variant_name=variant,
+                selected_view_layers=view_layers
+            )
         else:
             # Create a Compositor node
             node: bpy.types.CompositorNodeOutputFile = tree.nodes.new(
@@ -233,6 +238,9 @@ class CreateRender(plugin.BlenderCreator):
         return defs
 
     def get_pre_create_attr_defs(self):
+        view_layer_items: list[str] = [
+            layer.name for layer in bpy.context.scene.view_layers
+        ]
         return [
             BoolDef(
                 "create_render_setup",
@@ -240,7 +248,12 @@ class CreateRender(plugin.BlenderCreator):
                 default=False,
                 tooltip="Create Render Setup",
             ),
-
+            EnumDef("view_layers",
+                    items=view_layer_items,
+                    label="View Layers",
+                    multiselection=True,
+                    tooltip="Select view layers to include in the render setup"
+            ),
         ]
 
     def imprint(self, node: bpy.types.CompositorNodeOutputFile, data: dict):

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -15,10 +15,10 @@ BLENDER_VERSION = lib.get_blender_version()
 def clean_name(name: str) -> str:
     """Ensure variant name is valid, e.g. strip spaces from name"""
     # Entity name regex taken from server code which also applies to
-    # product names (which usually
+    # product names (which also follows the same rules).
     name_regex = r"^[a-zA-Z0-9_]([a-zA-Z0-9_\.\-]*[a-zA-Z0-9_])?$"
 
-    # Replace space with underscore
+    # Remove spaces
     clean = name.replace(" ", "")
     # Strip out any remaining invalid characters
     clean = re.sub(r"[^a-zA-Z0-9_.-]", "", clean)
@@ -74,21 +74,6 @@ class CreateRender(plugin.BlenderCreator):
                 selected_view_layers=view_layers
             )
 
-            project_name = self.create_context.get_current_project_name()
-            project_entity = self.create_context.get_current_project_entity()
-            folder_entity = self.create_context.get_current_folder_entity()
-            task_entity = self.create_context.get_current_task_entity()
-
-            variant = clean_name(node.name)
-            product_name = self.get_product_name(
-                project_name=project_name,
-                project_entity=project_entity,
-                folder_entity=folder_entity,
-                task_entity=task_entity,
-                variant=variant,
-                host_name=self.create_context.host_name,
-                product_type=self.product_base_type,
-            )
         else:
             project_settings = (
                 self.create_context.get_current_project_settings()
@@ -123,11 +108,27 @@ class CreateRender(plugin.BlenderCreator):
                 node.name = variant
                 node.label = variant
 
-
         self.set_instance_data(product_name, instance_data)
+
+        project_name = self.create_context.get_current_project_name()
+        project_entity = self.create_context.get_current_project_entity()
+        folder_entity = self.create_context.get_current_folder_entity()
+        task_entity = self.create_context.get_current_task_entity()
+
         product_type = instance_data.get("productType")
         if not product_type:
             product_type = self.product_base_type
+
+        variant = clean_name(node.name)
+        product_name = self.get_product_name(
+            project_name=project_name,
+            project_entity=project_entity,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=variant,
+            host_name=self.create_context.host_name,
+            product_type=self.product_base_type,
+        )
 
         instance = CreatedInstance(
             product_base_type=self.product_base_type,
@@ -162,8 +163,6 @@ class CreateRender(plugin.BlenderCreator):
         # Convert legacy instances that did not yet imprint on the
         # compositor node itself
         for instance in self.create_context.instances:
-            instance: CreatedInstance
-
             # Ignore instances from other creators
             if instance.creator_identifier != self.identifier:
                 continue
@@ -241,7 +240,6 @@ class CreateRender(plugin.BlenderCreator):
             self._add_instance_to_context(instance)
 
     def get_instance_attr_defs(self):
-
         render_target_items: dict[str, str] = {
             "local": "Local machine rendering",
             "local_no_render": "Use existing frames (local)",

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -88,8 +88,6 @@ class CreateRender(plugin.BlenderCreator):
                 project_settings
             )
 
-        self.set_instance_data(product_name, instance_data)
-
         project_name = self.create_context.get_current_project_name()
         project_entity = self.create_context.get_current_project_entity()
         folder_entity = self.create_context.get_current_folder_entity()
@@ -107,9 +105,11 @@ class CreateRender(plugin.BlenderCreator):
             task_entity=task_entity,
             variant=variant,
             host_name=self.create_context.host_name,
-            product_type=self.product_base_type,
+            product_type=product_type,
         )
 
+        instance_data["productName"] = product_name
+        self.set_instance_data(product_name, instance_data)
         instance = CreatedInstance(
             product_base_type=self.product_base_type,
             product_type=product_type,
@@ -256,6 +256,7 @@ class CreateRender(plugin.BlenderCreator):
                     items=view_layer_items,
                     label="View Layers",
                     multiselection=True,
+                    default=[],
                     tooltip="Select view layers to include in the render setup"
             ),
         ]


### PR DESCRIPTION
## Changelog Description
This PR is to add the options for selected view layers in create render. With this option, users can select particular view layers when creating rendersetup enabled and then create rendersetup with just those view layers

Fixes: https://github.com/ynput/ayon-blender/issues/206

## Additional review information
n/a

## Testing notes:
1. Create Render Instance with rendersetup enabled and selected viewlayers
2. Publish
3. Create Render Instance with rendersetup enabled without any selected viewlayers
4. The system would create rendersetup with all available viewlayers
5. Publish 
