### PR TITLE
Extract USD: Synchronize USD export options from Ayon to Publisher

### DIFF
--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -26,7 +26,7 @@ class ExtractUSD(plugin.BlenderExtractor,
     export_mesh_colors = True
     use_instancing = True
 
-    overrides = []
+    overrides: list[str] = []
 
     def process(self, instance):
         if not self.is_active(instance.data):

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -1,6 +1,4 @@
 import os
-from collections import OrderedDict
-
 import bpy
 
 from ayon_core.pipeline import KnownPublishError, OptionalPyblishPluginMixin
@@ -154,7 +152,7 @@ class ExtractUSD(plugin.BlenderExtractor,
         if not overrides:
             return defs
 
-        override_defs = OrderedDict({
+        override_defs = {
             "convert_orientation": BoolDef("convert_orientation",
                     label="Convert Orientation",
                     tooltip="Convert orientation axis to a different"
@@ -205,8 +203,7 @@ class ExtractUSD(plugin.BlenderExtractor,
                 label="Instancing",
                 tooltip="Whether to use USD instancing for duplicated objects or not.",
                 default=cls.use_instancing),
-
-        })
+        }
 
         for key, value in override_defs.items():
             if key not in overrides and key not in {"forward_axis", "up_axis"}:

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -150,56 +150,73 @@ class ExtractUSD(plugin.BlenderExtractor,
             return defs
 
         override_defs = {
-            "convert_orientation": BoolDef("convert_orientation",
-                    label="Convert Orientation",
-                    tooltip="Convert orientation axis to a different"
-                    " convention to match other applications.",
-                    default=cls.convert_orientation),
-            "forward_axis": EnumDef("forward_axis",
-                    label="Forward Axis",
-                    items=orientation_axes,
-                    default="Z",
-                    visible=visible),
-            "up_axis": EnumDef("up_axis",
-                    label="Up Axis",
-                    items=orientation_axes,
-                    default="Y",
-                    visible=visible),
+            "convert_orientation": BoolDef(
+                "convert_orientation",
+                label="Convert Orientation",
+                tooltip="Convert orientation axis to a different convention"
+                        " to match other applications.",
+                default=cls.convert_orientation,
+            ),
+            "forward_axis": EnumDef(
+                "forward_axis",
+                label="Forward Axis",
+                items=orientation_axes,
+                default="Z",
+                tooltip="Forward Axis for orientation conversion.",
+                visible=visible,
+            ),
+            "up_axis": EnumDef(
+                "up_axis",
+                label="Up Axis",
+                items=orientation_axes,
+                default="Y",
+                tooltip="Up Axis for orientation conversion.",
+                visible=visible,
+            ),
             "export_animation": BoolDef(
                 "export_animation",
                 label="Export Animation",
                 tooltip="Whether to export animation data or not.",
-                default=cls.export_animation),
+                default=cls.export_animation,
+            ),
             "export_hair": BoolDef(
                 "export_hair",
                 label="Export Hair",
                 tooltip="Whether to export hair/fur systems or not.",
-                default=cls.export_hair),
+                default=cls.export_hair,
+            ),
             "export_uvmaps": BoolDef(
                 "export_uvmaps",
                 label="Export UV Maps",
                 tooltip="Whether to export UV map data or not.",
-                default=cls.export_uvmaps),
+                default=cls.export_uvmaps,
+            ),
             "export_normals": BoolDef(
                 "export_normals",
                 label="Export Normals",
                 tooltip="Whether to export normal data or not.",
-                default=cls.export_normals),
+                default=cls.export_normals,
+            ),
             "export_materials": BoolDef(
                 "export_materials",
                 label="Export Materials",
-                tooltip="Whether to export material assignments and data or not.",
-                default=cls.export_materials),
+                tooltip="Whether to export material assignments and data or"
+                        " not.",
+                default=cls.export_materials,
+            ),
             "export_mesh_colors": BoolDef(
                 "export_mesh_colors",
                 label="Export Mesh Colors",
                 tooltip="Whether to export mesh color data or not.",
-                default=cls.export_mesh_colors),
+                default=cls.export_mesh_colors,
+            ),
             "use_instancing": BoolDef(
                 "use_instancing",
                 label="Instancing",
-                tooltip="Whether to use USD instancing for duplicated objects or not.",
-                default=cls.use_instancing),
+                tooltip="Whether to use USD instancing for duplicated objects"
+                        " or not.",
+                default=cls.use_instancing,
+            ),
         }
 
         for key, value in override_defs.items():

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -15,7 +15,14 @@ class ExtractUSD(plugin.BlenderExtractor,
     hosts = ["blender"]
     families = ["usd"]
 
+    # Settings
     convert_orientation = False
+    export_animation=False
+    export_hair=False
+    export_uvmaps=True
+    export_normals=True
+    export_materials=True
+    use_instancing=True
 
     def process(self, instance):
         if not self.is_active(instance.data):
@@ -63,6 +70,12 @@ class ExtractUSD(plugin.BlenderExtractor,
             "convert_orientation": convert_orientation,
             "export_global_forward_selection": attribute_values.get("forward_axis", "Z"),
             "export_global_up_selection": attribute_values.get("up_axis", "Y"),
+            "export_animation": attribute_values.get("export_animation", self.export_animation),
+            "export_hair": attribute_values.get("export_hair", self.export_hair),
+            "export_uvmaps": attribute_values.get("export_uvmaps", self.export_uvmaps),
+            "export_normals": attribute_values.get("export_normals", self.export_normals),
+            "export_materials": attribute_values.get("export_materials", self.export_materials),
+            "use_instancing": attribute_values.get("use_instancing", self.use_instancing),
         }
 
         blender_version = lib.get_blender_version()
@@ -90,15 +103,6 @@ class ExtractUSD(plugin.BlenderExtractor,
                 root_prim_path="",  
                 selected_objects_only=True,
                 relative_paths=False,
-                export_animation=False,
-                export_hair=False,
-                export_uvmaps=True,
-                # TODO: add for new version of Blender (4+?)
-                # export_mesh_colors=True,
-                export_normals=True,
-                export_materials=True,
-                use_instancing=True,
-                # Convert Orientation
                 **kwargs
             )
 
@@ -136,7 +140,7 @@ class ExtractUSD(plugin.BlenderExtractor,
             "NEGATIVE_Y": "-Y",
             "NEGATIVE_Z": "-Z",
         }
-                
+
         return [
             BoolDef("convert_orientation",
                     label="Convert Orientation",
@@ -152,9 +156,33 @@ class ExtractUSD(plugin.BlenderExtractor,
                     label="Up Axis",
                     items=orientation_axes,
                     default="Y",
-                    visible=visible)
+                    visible=visible),
+            BoolDef("export_animation",
+                    label="Animation",
+                    tooltip="Export animation data",
+                    default=cls.export_animation),
+            BoolDef("export_hair",
+                    label="Hair",
+                    tooltip="Export hair/fur systems",
+                    default=cls.export_hair),
+            BoolDef("export_uvmaps",
+                    label="UV Maps",
+                    tooltip="Export UV map data",
+                    default=cls.export_uvmaps),
+            BoolDef("export_normals",
+                    label="Normals",
+                    tooltip="Export normal data",
+                    default=cls.export_normals),
+            BoolDef("export_materials",
+                    label="Materials",
+                    tooltip="Export material assignments and data",
+                    default=cls.export_materials),
+            BoolDef("use_instancing",
+                    label="Instancing",
+                    tooltip="Use USD instancing for duplicated objects",
+                    default=cls.use_instancing),
         ]
-    
+
     @classmethod
     def register_create_context_callbacks(cls, create_context):
         create_context.add_value_changed_callback(cls.on_values_changed)

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -134,10 +134,7 @@ class ExtractUSD(plugin.BlenderExtractor,
 
         defs = []
 
-        visible = (
-            publish_attributes.get("convert_orientation", cls.convert_orientation)
-            | cls.convert_orientation
-        )
+        visible = publish_attributes.get("convert_orientation", cls.convert_orientation)
 
         orientation_axes = {
             "X": "X",

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -144,11 +144,6 @@ class ExtractUSD(plugin.BlenderExtractor,
         }
 
         defs = [
-            BoolDef("convert_orientation",
-                    label="Convert Orientation",
-                    tooltip="Convert orientation axis to a different"
-                    " convention to match other applications.",
-                    default=cls.convert_orientation),
             EnumDef("forward_axis",
                     label="Forward Axis",
                     items=orientation_axes,
@@ -165,6 +160,11 @@ class ExtractUSD(plugin.BlenderExtractor,
             return defs
 
         override_defs = OrderedDict({
+            "convert_orientation": BoolDef("convert_orientation",
+                    label="Convert Orientation",
+                    tooltip="Convert orientation axis to a different"
+                    " convention to match other applications.",
+                    default=cls.convert_orientation),
             "export_animation": BoolDef(
                 "export_animation",
                 label="Export Animation",

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -23,6 +23,7 @@ class ExtractUSD(plugin.BlenderExtractor,
     export_uvmaps = True
     export_normals = True
     export_materials = True
+    export_mesh_colors = True
     use_instancing = True
 
     overrides = []
@@ -77,6 +78,7 @@ class ExtractUSD(plugin.BlenderExtractor,
             "export_uvmaps": attribute_values.get("export_uvmaps", self.export_uvmaps),
             "export_normals": attribute_values.get("export_normals", self.export_normals),
             "export_materials": attribute_values.get("export_materials", self.export_materials),
+            "export_mesh_colors": attribute_values.get("export_mesh_colors", self.export_mesh_colors),
             "use_instancing": attribute_values.get("use_instancing", self.use_instancing),
         }
 
@@ -193,6 +195,11 @@ class ExtractUSD(plugin.BlenderExtractor,
                 label="Export Materials",
                 tooltip="Whether to export material assignments and data or not.",
                 default=cls.export_materials),
+            "export_mesh_colors": BoolDef(
+                "export_mesh_colors",
+                label="Export Mesh Colors",
+                tooltip="Whether to export mesh color data or not.",
+                default=cls.export_mesh_colors),
             "use_instancing": BoolDef(
                 "use_instancing",
                 label="Instancing",

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -150,7 +150,7 @@ class ExtractUSD(plugin.BlenderExtractor,
             "NEGATIVE_Z": "-Z",
         }
 
-        overrides = publish_attributes.get("overrides", cls.overrides)
+        overrides: set[str] = set(cls.overrides)
         if not overrides:
             return defs
 

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -205,7 +205,6 @@ class ExtractUSD(plugin.BlenderExtractor,
             if key not in overrides and key not in {"forward_axis", "up_axis"}:
                 continue
 
-
             defs.append(value)
 
         return defs

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -1,4 +1,5 @@
 import os
+from collections import OrderedDict
 
 import bpy
 
@@ -17,17 +18,18 @@ class ExtractUSD(plugin.BlenderExtractor,
 
     # Settings
     convert_orientation = False
-    export_animation=False
-    export_hair=False
-    export_uvmaps=True
-    export_normals=True
-    export_materials=True
-    use_instancing=True
+    export_animation = False
+    export_hair = False
+    export_uvmaps = True
+    export_normals = True
+    export_materials = True
+    use_instancing = True
+
+    overrides = []
 
     def process(self, instance):
         if not self.is_active(instance.data):
             return
-
         # Ignore runtime instances (e.g. USD layers)
         # TODO: This is better done via more specific `families`
         if not instance.data.get("transientData", {}).get("instance_node"):
@@ -60,7 +62,7 @@ class ExtractUSD(plugin.BlenderExtractor,
 
         context = plugin.create_blender_context(
             active=root, selected=selected)
-        
+
         attribute_values = self.get_attr_values_from_data(instance.data)
         convert_orientation = attribute_values.get(
             "convert_orientation",
@@ -97,10 +99,10 @@ class ExtractUSD(plugin.BlenderExtractor,
         # Export USD
         with bpy.context.temp_override(**context):
             bpy.ops.wm.usd_export(
-                # Override the `/root` default value. If left as an empty 
+                # Override the `/root` default value. If left as an empty
                 # string, Blender will use the top-level object as the root prim.
                 filepath=filepath,
-                root_prim_path="",  
+                root_prim_path="",
                 selected_objects_only=True,
                 relative_paths=False,
                 **kwargs
@@ -118,13 +120,13 @@ class ExtractUSD(plugin.BlenderExtractor,
         instance.data.setdefault("representations", []).append(representation)
         self.log.debug("Extracted instance '%s' to: %s",
                        instance.name, representation)
-    
+
     @classmethod
     def get_attr_defs_for_instance(cls, create_context, instance):
         # Filtering of instance, if needed, can be customized
         if not cls.instance_matches_plugin_families(instance):
             return []
-        
+
         # Attributes logic
         publish_attributes = cls.get_attr_values_from_data_for_plugin(
             cls, instance
@@ -134,14 +136,14 @@ class ExtractUSD(plugin.BlenderExtractor,
 
         orientation_axes = {
             "X": "X",
-            "Y": "Y",  
+            "Y": "Y",
             "Z": "Z",
             "NEGATIVE_X": "-X",
             "NEGATIVE_Y": "-Y",
             "NEGATIVE_Z": "-Z",
         }
 
-        return [
+        defs = [
             BoolDef("convert_orientation",
                     label="Convert Orientation",
                     tooltip="Convert orientation axis to a different"
@@ -157,31 +159,52 @@ class ExtractUSD(plugin.BlenderExtractor,
                     items=orientation_axes,
                     default="Y",
                     visible=visible),
-            BoolDef("export_animation",
-                    label="Animation",
-                    tooltip="Export animation data",
-                    default=cls.export_animation),
-            BoolDef("export_hair",
-                    label="Hair",
-                    tooltip="Export hair/fur systems",
-                    default=cls.export_hair),
-            BoolDef("export_uvmaps",
-                    label="UV Maps",
-                    tooltip="Export UV map data",
-                    default=cls.export_uvmaps),
-            BoolDef("export_normals",
-                    label="Normals",
-                    tooltip="Export normal data",
-                    default=cls.export_normals),
-            BoolDef("export_materials",
-                    label="Materials",
-                    tooltip="Export material assignments and data",
-                    default=cls.export_materials),
-            BoolDef("use_instancing",
-                    label="Instancing",
-                    tooltip="Use USD instancing for duplicated objects",
-                    default=cls.use_instancing),
         ]
+        overrides = publish_attributes.get("overrides", cls.overrides)
+        if not overrides:
+            return defs
+
+        override_defs = OrderedDict({
+            "export_animation": BoolDef(
+                "export_animation",
+                label="Export Animation",
+                tooltip="Whether to export animation data or not.",
+                default=cls.export_animation),
+            "export_hair": BoolDef(
+                "export_hair",
+                label="Export Hair",
+                tooltip="Whether to export hair/fur systems or not.",
+                default=cls.export_hair),
+            "export_uvmaps": BoolDef(
+                "export_uvmaps",
+                label="Export UV Maps",
+                tooltip="Whether to export UV map data or not.",
+                default=cls.export_uvmaps),
+            "export_normals": BoolDef(
+                "export_normals",
+                label="Export Normals",
+                tooltip="Whether to export normal data or not.",
+                default=cls.export_normals),
+            "export_materials": BoolDef(
+                "export_materials",
+                label="Export Materials",
+                tooltip="Whether to export material assignments and data or not.",
+                default=cls.export_materials),
+            "use_instancing": BoolDef(
+                "use_instancing",
+                label="Instancing",
+                tooltip="Whether to use USD instancing for duplicated objects or not.",
+                default=cls.use_instancing),
+
+        })
+        overrides = set(overrides)
+        for key, value in override_defs.items():
+            if key not in overrides:
+                continue
+
+            defs.append(value)
+
+        return defs
 
     @classmethod
     def register_create_context_callbacks(cls, create_context):

--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -132,7 +132,12 @@ class ExtractUSD(plugin.BlenderExtractor,
             cls, instance
         )
 
-        visible = publish_attributes.get("convert_orientation", cls.convert_orientation)
+        defs = []
+
+        visible = (
+            publish_attributes.get("convert_orientation", cls.convert_orientation)
+            | cls.convert_orientation
+        )
 
         orientation_axes = {
             "X": "X",
@@ -143,18 +148,6 @@ class ExtractUSD(plugin.BlenderExtractor,
             "NEGATIVE_Z": "-Z",
         }
 
-        defs = [
-            EnumDef("forward_axis",
-                    label="Forward Axis",
-                    items=orientation_axes,
-                    default="Z",
-                    visible=visible),
-            EnumDef("up_axis",
-                    label="Up Axis",
-                    items=orientation_axes,
-                    default="Y",
-                    visible=visible),
-        ]
         overrides = publish_attributes.get("overrides", cls.overrides)
         if not overrides:
             return defs
@@ -165,6 +158,16 @@ class ExtractUSD(plugin.BlenderExtractor,
                     tooltip="Convert orientation axis to a different"
                     " convention to match other applications.",
                     default=cls.convert_orientation),
+            "forward_axis": EnumDef("forward_axis",
+                    label="Forward Axis",
+                    items=orientation_axes,
+                    default="Z",
+                    visible=visible),
+            "up_axis": EnumDef("up_axis",
+                    label="Up Axis",
+                    items=orientation_axes,
+                    default="Y",
+                    visible=visible),
             "export_animation": BoolDef(
                 "export_animation",
                 label="Export Animation",
@@ -197,10 +200,11 @@ class ExtractUSD(plugin.BlenderExtractor,
                 default=cls.use_instancing),
 
         })
-        overrides = set(overrides)
+
         for key, value in override_defs.items():
-            if key not in overrides:
+            if key not in overrides and key not in {"forward_axis", "up_axis"}:
                 continue
+
 
             defs.append(value)
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -35,6 +35,7 @@ def evaluation_mode_enum():
 
 def extract_model_usd_overrides_enum():
     return [
+        {"label": "Convert Orientation", "value": "convert_orientation"},
         {"label": "Export Animation", "value": "export_animation"},
         {"label": "Export Hair", "value": "export_hair"},
         {"label": "Export UV Maps", "value": "export_uvmaps"},
@@ -44,7 +45,7 @@ def extract_model_usd_overrides_enum():
     ]
 
 
-class ExtractModelUSDModel(BaseSettingsModel):
+class ExtractUSDModel(BaseSettingsModel):
     convert_orientation: bool = SettingsField(
         False,
         title="Convert Orientation",
@@ -289,8 +290,8 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=ExtractPlayblastModel,
         title="Extract Playblast"
     )
-    ExtractUSD: ExtractModelUSDModel = SettingsField(
-        default_factory=ExtractModelUSDModel,
+    ExtractUSD: ExtractUSDModel = SettingsField(
+        default_factory=ExtractUSDModel,
         title="Extract USD"
     )
     ExtractModelUSD: ValidatePluginModel = SettingsField(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -32,6 +32,46 @@ def evaluation_mode_enum():
         {"label": "Viewport", "value": "VIEWPORT"},
     ]
 
+class ExtractModelUSDModel(BaseSettingsModel):
+    enabled: bool = SettingsField(True)
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+    convert_orientation: bool = SettingsField(
+        False,
+        title="Convert Orientation",
+        description="Convert Orientation settings for USD export"
+    )
+    export_animation: bool = SettingsField(
+        False,
+        title="Animation",
+        description="Whether to export animation data or not."
+    )
+    export_hair: bool = SettingsField(
+        False,
+        title="Hair",
+        description="Whether to export hair/fur systems or not."
+    )
+    export_uvmaps: bool = SettingsField(
+        False,
+        title="UV Maps",
+        description="Whether to export UV map data or not."
+    )
+    export_normals: bool = SettingsField(
+        False,
+        title="Normals",
+        description="Whether to export normal data or not."
+    )
+    export_materials: bool = SettingsField(
+        False,
+        title="Materials",
+        description="Whether to export material assignments and data or not."
+    )
+    use_instancing: bool = SettingsField(
+        False,
+        title="Instancing",
+        description="Whether to use USD instancing for duplicated objects or not."
+    )
+
 
 class AlembicEvaluationModeModel(BaseSettingsModel):
     subdiv_schema: bool = SettingsField(
@@ -233,8 +273,8 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=ExtractPlayblastModel,
         title="Extract Playblast"
     )
-    ExtractModelUSD: ValidatePluginModel = SettingsField(
-        default_factory=ValidatePluginModel,
+    ExtractModelUSD: ExtractModelUSDModel = SettingsField(
+        default_factory=ExtractModelUSDModel,
         title="Extract Model USD"
     )
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -41,6 +41,7 @@ def extract_model_usd_overrides_enum():
         {"label": "Export UV Maps", "value": "export_uvmaps"},
         {"label": "Export Normals", "value": "export_normals"},
         {"label": "Export Materials", "value": "export_materials"},
+        {"label": "Export Mesh Colors", "value": "export_mesh_colors"},
         {"label": "Use Instancing", "value": "use_instancing"},
     ]
 
@@ -75,6 +76,11 @@ class ExtractUSDModel(BaseSettingsModel):
         True,
         title="Materials",
         description="Whether to export material assignments and data or not."
+    )
+    export_mesh_colors: bool = SettingsField(
+        True,
+        title="Mesh Colors",
+        description="Whether to export mesh color data or not."
     )
     use_instancing: bool = SettingsField(
         True,
@@ -531,6 +537,7 @@ DEFAULT_BLENDER_PUBLISH_SETTINGS = {
         "export_uvmaps": True,
         "export_normals": True,
         "export_materials": True,
+        "export_mesh_colors": True,
         "use_instancing": True,
         "overrides": []
     },

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -32,10 +32,19 @@ def evaluation_mode_enum():
         {"label": "Viewport", "value": "VIEWPORT"},
     ]
 
+
+def extract_model_usd_overrides_enum():
+    return [
+        {"label": "Export Animation", "value": "export_animation"},
+        {"label": "Export Hair", "value": "export_hair"},
+        {"label": "Export UV Maps", "value": "export_uvmaps"},
+        {"label": "Export Normals", "value": "export_normals"},
+        {"label": "Export Materials", "value": "export_materials"},
+        {"label": "Use Instancing", "value": "use_instancing"},
+    ]
+
+
 class ExtractModelUSDModel(BaseSettingsModel):
-    enabled: bool = SettingsField(True)
-    optional: bool = SettingsField(title="Optional")
-    active: bool = SettingsField(title="Active")
     convert_orientation: bool = SettingsField(
         False,
         title="Convert Orientation",
@@ -52,24 +61,31 @@ class ExtractModelUSDModel(BaseSettingsModel):
         description="Whether to export hair/fur systems or not."
     )
     export_uvmaps: bool = SettingsField(
-        False,
+        True,
         title="UV Maps",
         description="Whether to export UV map data or not."
     )
     export_normals: bool = SettingsField(
-        False,
+        True,
         title="Normals",
         description="Whether to export normal data or not."
     )
     export_materials: bool = SettingsField(
-        False,
+        True,
         title="Materials",
         description="Whether to export material assignments and data or not."
     )
     use_instancing: bool = SettingsField(
-        False,
+        True,
         title="Instancing",
         description="Whether to use USD instancing for duplicated objects or not."
+    )
+    overrides: list[str] = SettingsField(
+        enum_resolver=extract_model_usd_overrides_enum,
+        title="Exposed Overrides",
+        description=(
+            "Expose the attribute in this list to the user when publishing."
+        )
     )
 
 
@@ -273,8 +289,12 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=ExtractPlayblastModel,
         title="Extract Playblast"
     )
-    ExtractModelUSD: ExtractModelUSDModel = SettingsField(
+    ExtractUSD: ExtractModelUSDModel = SettingsField(
         default_factory=ExtractModelUSDModel,
+        title="Extract USD"
+    )
+    ExtractModelUSD: ValidatePluginModel = SettingsField(
+        default_factory=ValidatePluginModel,
         title="Extract Model USD"
     )
 
@@ -502,6 +522,16 @@ DEFAULT_BLENDER_PUBLISH_SETTINGS = {
             },
             indent=4
         )
+    },
+    "ExtractUSD": {
+        "convert_orientation": False,
+        "export_animation": False,
+        "export_hair": False,
+        "export_uvmaps": True,
+        "export_normals": True,
+        "export_materials": True,
+        "use_instancing": True,
+        "overrides": []
     },
     "ExtractModelUSD": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
This PR is to synchronize USD export options from Ayon to Publisher, and to allow user to choose their preferred options.
Resolve https://github.com/ynput/ayon-blender/issues/291

## Additional review information
Build and install addon with this branch

## Testing notes:
1. Go to `ayon+settings://blender/publish/ExtractUSD` 
<img width="1091" height="539" alt="image" src="https://github.com/user-attachments/assets/4d6098a7-bd74-47bc-8d85-c93958ffe4d6" />

2. Create USD instance
3. You can see the options in the publisher UI
4. Publish 
