### PR TITLE
Append Blend: Loaded collection data renamed without error

### DIFF
--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -106,7 +106,11 @@ class BlendLoader(plugin.BlenderLoader):
         members = []
         for attr in dir(data_to):
             from_names: list[str] = names_by_attr[attr]
-            for from_name, data in zip(from_names, getattr(data_to, attr)):
+            values = getattr(data_to, attr)
+            if not isinstance(values, list):
+                continue
+
+            for from_name, data in zip(from_names, values):
                 data.name = f"{group_name}:{from_name}"
                 members.append(data)
 


### PR DESCRIPTION
## Changelog Description
This PR is to fix the bug when users appending blend scene and encounter error when the objects are being renamed.
Resolve https://github.com/ynput/ayon-blender/issues/297

## Additional review information
n/a

## Testing notes:
1. Append Blend in 4.x or 5.x
2. Should be all working
