### PR TITLE
Add materialx related settings as options for usd export

### DIFF
--- a/client/ayon_blender/plugins/publish/extract_usd.py
+++ b/client/ayon_blender/plugins/publish/extract_usd.py
@@ -22,6 +22,8 @@ class ExtractUSD(plugin.BlenderExtractor,
     export_normals = True
     export_materials = True
     export_mesh_colors = True
+    generate_preview_surface = True
+    generate_materialx_network = False
     use_instancing = True
 
     overrides: list[str] = []
@@ -77,6 +79,12 @@ class ExtractUSD(plugin.BlenderExtractor,
             "export_normals": attribute_values.get("export_normals", self.export_normals),
             "export_materials": attribute_values.get("export_materials", self.export_materials),
             "export_mesh_colors": attribute_values.get("export_mesh_colors", self.export_mesh_colors),
+            "generate_preview_surface": attribute_values.get(
+                "generate_preview_surface", self.generate_preview_surface
+            ),
+            "generate_materialx_network": attribute_values.get(
+                "generate_materialx_network", self.generate_materialx_network
+            ),
             "use_instancing": attribute_values.get("use_instancing", self.use_instancing),
         }
 
@@ -209,6 +217,18 @@ class ExtractUSD(plugin.BlenderExtractor,
                 label="Export Mesh Colors",
                 tooltip="Whether to export mesh color data or not.",
                 default=cls.export_mesh_colors,
+            ),
+            "generate_preview_surface": BoolDef(
+                "generate_preview_surface",
+                label="Generate Preview Surface",
+                tooltip="Whether to generate a preview surface for exported meshes or not.",
+                default=cls.generate_preview_surface,
+            ),
+            "generate_materialx_network": BoolDef(
+                "generate_materialx_network",
+                label="Generate MaterialX Network",
+                tooltip="Whether to generate a MaterialX network for exported materials or not.",
+                default=cls.generate_materialx_network,
             ),
             "use_instancing": BoolDef(
                 "use_instancing",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -42,6 +42,8 @@ def extract_model_usd_overrides_enum():
         {"label": "Export Normals", "value": "export_normals"},
         {"label": "Export Materials", "value": "export_materials"},
         {"label": "Export Mesh Colors", "value": "export_mesh_colors"},
+        {"label": "Generate Preview Surface", "value": "generate_preview_surface"},
+        {"label": "Generate MaterialX Network", "value": "generate_materialx_network"},
         {"label": "Use Instancing", "value": "use_instancing"},
     ]
 
@@ -81,6 +83,20 @@ class ExtractUSDModel(BaseSettingsModel):
         True,
         title="Mesh Colors",
         description="Whether to export mesh color data or not."
+    )
+    generate_preview_surface: bool = SettingsField(
+        True,
+        title="Generate Preview Surface",
+        description=(
+            "Whether to generate a preview surface for the exported geometry or not."
+        )
+    )
+    generate_materialx_network: bool = SettingsField(
+        False,
+        title="Generate MaterialX Network",
+        description=(
+            "Whether to generate a MaterialX network for the exported materials or not."
+        )
     )
     use_instancing: bool = SettingsField(
         True,
@@ -538,6 +554,8 @@ DEFAULT_BLENDER_PUBLISH_SETTINGS = {
         "export_normals": True,
         "export_materials": True,
         "export_mesh_colors": True,
+        "generate_preview_surface": True,
+        "generate_materialx_network": False,
         "use_instancing": True,
         "overrides": []
     },


### PR DESCRIPTION
## Changelog Description
This PR is to add materialx related setting as options for usd export.
Resolve https://github.com/ynput/ayon-blender/issues/299
## Additional review information
Build and install Blender addon with this branch
Tested with Blender4.x and 5.x
## Testing notes:
1. Launch Blender 
2. Create model
3. Publish. 
