### PR TITLE
Truncating names in blender during the load

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import traceback
 import importlib
@@ -997,3 +998,17 @@ def update_content_on_context_change():
 
     if has_changes:
         create_context.save_changes()
+
+
+def clean_filename(filename: str) -> str:
+    """Clean filename from characters which has reached more than maximum 63 characters.
+    It would be removed after fully supporting blender 5.0, because blender 5.0 supports
+    up to 255 characters for the name.
+
+    Args:
+        filename (str): The filename to clean.
+    Returns:
+        str: The cleaned filename.
+    """
+    digest = hashlib.sha1(filename.encode("utf-8")).hexdigest()[:8]
+    return f"{filename[:54]}_{digest}"

--- a/client/ayon_blender/api/plugin.py
+++ b/client/ayon_blender/api/plugin.py
@@ -33,7 +33,8 @@ from .ops import (
 from .lib import (
     imprint,
     get_blender_version,
-    get_scene_node_tree
+    get_scene_node_tree,
+    clean_filename
 )
 
 
@@ -50,7 +51,7 @@ def prepare_scene_name(
     # characters. If the name is longer, it will raise an error.
     # The truncation will only happen for blender version elder than 5.0
     if get_blender_version() < (5, 0, 0) and len(name) > 63:
-        name = name[:63]
+        name = clean_filename(name)
 
     return name
 

--- a/client/ayon_blender/api/plugin.py
+++ b/client/ayon_blender/api/plugin.py
@@ -50,7 +50,7 @@ def prepare_scene_name(
     # characters. If the name is longer, it will raise an error.
     # The truncation will only happen for blender version elder than 5.0
     if get_blender_version() < (5, 0, 0) and len(name) > 63:
-        raise ValueError(f"Scene name '{name}' would be too long.")
+        name = name[:63]
 
     return name
 

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -9,7 +9,8 @@ from ayon_blender.api import plugin
 from ayon_blender.api.lib import (
     imprint,
     get_blender_version,
-    create_animation_instance
+    create_animation_instance,
+    clean_filename,
 )
 from ayon_blender.api.pipeline import (
     add_to_ayon_container,
@@ -131,7 +132,7 @@ class BlendLoader(plugin.BlenderLoader):
         # If the filename is longer, it will be truncated for blender
         # version elder than 5.0
         if get_blender_version() < (5, 0, 0) and len(filepath) > 63:
-            filepath = filepath[:63]
+            filepath = clean_filename(filepath)
         library = bpy.data.libraries.get(filepath)
         bpy.data.libraries.remove(library)
 

--- a/client/ayon_blender/plugins/load/load_blendscene.py
+++ b/client/ayon_blender/plugins/load/load_blendscene.py
@@ -8,7 +8,8 @@ from ayon_core.pipeline import AYON_CONTAINER_ID
 from ayon_blender.api import plugin
 from ayon_blender.api.lib import (
     imprint,
-    get_blender_version
+    get_blender_version,
+    clean_filename,
 )
 from ayon_blender.api.constants import (
     AYON_CONTAINERS,
@@ -86,7 +87,7 @@ class BlendSceneLoader(plugin.BlenderLoader):
         # If the filepath is longer, it will be truncated for blender
         # version elder than 5.0
         if get_blender_version() < (5, 0, 0) and len(filepath) > 63:
-            filepath = filepath[:63]
+            filepath = clean_filename(filepath)
         library = bpy.data.libraries.get(filepath)
         bpy.data.libraries.remove(library)
 


### PR DESCRIPTION
## Changelog Description
This PR is to truncate names of the loaded asset in blender during the load for users with blender 4.x to make sure they won't encounter the error caused by the maximum limit of character.
Resolve https://github.com/ynput/ayon-blender/issues/276

## Additional review information
Tested with blender 4.x and 5.x

## Testing notes:
1. Load assets in Blender
2. No error encountered and all assets registered to the scene inventory correctly.
