### PR TITLE
Load Blend: Converting blender-type data list to python list before adding and updating the list as container data

### DIFF
--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -277,7 +277,8 @@ class BlendLoader(plugin.BlenderLoader):
         parent_containers = self.get_all_container_parents(asset_group)
 
         for parent_container in parent_containers:
-            parent_members = parent_container[AYON_PROPERTY]["members"]
+            parent_members = parent_container[AYON_PROPERTY].get("members", [])
+            parent_members = parent_members.tolist()
             parent_container[AYON_PROPERTY]["members"] = (
                 parent_members + members)
 

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -278,7 +278,11 @@ class BlendLoader(plugin.BlenderLoader):
 
         for parent_container in parent_containers:
             parent_members = parent_container[AYON_PROPERTY].get("members", [])
-            parent_members = parent_members.tolist()
+            parent_members = (
+                parent_members.tolist() 
+                if not isinstance(parent_members, list) 
+                else parent_members
+            )
             parent_container[AYON_PROPERTY]["members"] = (
                 parent_members + members)
 


### PR DESCRIPTION
## Changelog Description
This PR is to make sure converting blender-type data list to python list before adding and updating the list as container data.
Fixes https://github.com/ynput/ayon-blender/issues/303

## Additional review information
n/a

## Testing notes:
1. Launch Blender
2. Load Blend