### PR TITLE
Workfile template: Check on window is None when opening template

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -471,6 +471,8 @@ class OpenTemplate(LaunchQtApp):
     def execute(self, context):
         from .workfile_template_builder import open_template
         window = open_template()
+        if window is None:
+            return {"FINISHED"}
         BlenderApplication.store_window(self.bl_idname, window)
         self._window = window
         return super().execute(context)

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -217,7 +217,7 @@ def _process_app_events() -> Optional[float]:
 class LaunchQtApp(bpy.types.Operator):
     """A Base class for operators to launch a Qt app."""
 
-    _window = Union[QtWidgets.QDialog, ModuleType]
+    _window: Optional[Union[QtWidgets.QDialog, ModuleType]] = None
     _tool_name: str = None
     _init_args: Optional[List] = list()
     _init_kwargs: Optional[Dict] = dict()
@@ -250,7 +250,9 @@ class LaunchQtApp(bpy.types.Operator):
 
         if self._tool_name is None:
             if self._window is None:
-                raise AttributeError("`self._window` is not set.")
+                self._window = BlenderApplication.get_window(self.bl_idname)
+                if self._window is None:
+                    raise AttributeError("`self._window` is not set.")
 
         else:
             window = BlenderApplication.get_window(self.bl_idname)
@@ -464,18 +466,14 @@ class BuildWorkfileFromTemplate(LaunchQtApp):
 
 
 class OpenTemplate(LaunchQtApp):
-    """Build Workfile from ayon template settings."""
+    """Open workfile template."""
 
     bl_idname = "wm.ayon_open_template"
     bl_label = "Open Template"
     def execute(self, context):
         from .workfile_template_builder import open_template
-        window = open_template()
-        if window is None:
-            return {"FINISHED"}
-        BlenderApplication.store_window(self.bl_idname, window)
-        self._window = window
-        return super().execute(context)
+        open_template()
+        return {"FINISHED"}
 
 
 

--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -250,9 +250,7 @@ class LaunchQtApp(bpy.types.Operator):
 
         if self._tool_name is None:
             if self._window is None:
-                self._window = BlenderApplication.get_window(self.bl_idname)
-                if self._window is None:
-                    raise AttributeError("`self._window` is not set.")
+                raise AttributeError("`self._window` is not set.")
 
         else:
             window = BlenderApplication.get_window(self.bl_idname)

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -259,7 +259,6 @@ def open_template(*args, **kwargs):
     open_template_ui(builder, main_window=main_window)
 
 
-
 def create_placeholder(*args, **kwargs):
     """Create Workfile Placeholder for Blender."""
     host = registered_host()

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -252,12 +252,12 @@ def build_workfile_template(*args) -> None:
 #     builder.rebuild_template()
 
 
-def open_template(*args, **kwargs) -> None:
+def open_template(*args, **kwargs):
     """Open workfile template for Blender."""
     builder = BlenderTemplateBuilder(registered_host())
     main_window = kwargs.get("main_window")
     open_template_ui(builder, main_window=main_window)
-    return main_window
+
 
 
 def create_placeholder(*args, **kwargs):


### PR DESCRIPTION
## Changelog Description
This PR is to ensure opening template won't hit error and still performs as usual along with other plugins. 

## Additional review information
fix https://github.com/ynput/ayon-blender/issues/307

## Testing notes:
1. Launch Blender
2. Templated Workfile -> Open Template
3. The window-related error from ops.py should be gone.
