### PR TITLE
First workfile creation with templated workfile build

### DIFF
--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -28,9 +28,6 @@ from ayon_core.pipeline import (
 from ayon_core.pipeline.context_tools import (
     get_current_task_entity
 )
-from ayon_core.pipeline.workfile.workfile_template_builder import (
-    TemplateProfileNotFound
-)
 from ayon_core.lib import (
     Logger,
     register_event_callback,
@@ -417,11 +414,6 @@ def _create_first_workfile_from_template_timer() -> Optional[float]:
         )
         _is_opening_workfile_template = True
         create_first_workfile_from_template()
-
-    except TemplateProfileNotFound:
-        # to avoid looping of the callback, remove it!
-        log.warning("Template profile not found. Skipping...")
-        _is_opening_workfile_template = False
 
     except Exception:
         log.warning(

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -420,7 +420,6 @@ def _create_first_workfile_from_template_timer() -> Optional[float]:
             "Failed to create first workfile from template on new file.",
             exc_info=True,
         )
-        _is_opening_workfile_template = False
 
     finally:
         _is_opening_workfile_template = False

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -407,11 +407,11 @@ def _create_first_workfile_from_template_deferred() -> Optional[float]:
     if not window_manager or not scene:
         return 0.1
 
+    global _is_opening_workfile_template
     try:
         from .workfile_template_builder import (
             create_first_workfile_from_template,
         )
-        global _is_opening_workfile_template
         _is_opening_workfile_template = True
         create_first_workfile_from_template()
     except Exception:

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -391,6 +391,11 @@ def on_new():
 
     set_unit_scale_from_settings(blender_settings=settings)
 
+    if not IS_HEADLESS:
+        from .workfile_template_builder import create_first_workfile_from_template
+        create_first_workfile_from_template()
+
+
 
 def on_open():
     project = os.environ.get("AYON_PROJECT_NAME")

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -396,7 +396,6 @@ def on_new():
         create_first_workfile_from_template()
 
 
-
 def on_open():
     project = os.environ.get("AYON_PROJECT_NAME")
     settings = get_blender_settings(project)

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -70,6 +70,7 @@ ORIGINAL_EXCEPTHOOK = sys.excepthook
 
 
 log = Logger.get_logger(__name__)
+_is_opening_template = False
 
 
 class BlenderHost(HostBase, IWorkfileHost, IPublishHost, ILoadHost):
@@ -410,6 +411,8 @@ def _create_first_workfile_from_template_deferred() -> Optional[float]:
         from .workfile_template_builder import (
             create_first_workfile_from_template,
         )
+        global _is_opening_template
+        _is_opening_template = True
         create_first_workfile_from_template()
     except Exception:
         log.warning(
@@ -511,7 +514,8 @@ def _on_load_post(*args):
         # Likely this was an open operation since it has a filepath
         emit_event("open")
     else:
-        emit_event("new")
+        if not _is_opening_template:
+            emit_event("new")
 
     ops.OpenFileCacher.post_load()
 

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -28,6 +28,9 @@ from ayon_core.pipeline import (
 from ayon_core.pipeline.context_tools import (
     get_current_task_entity
 )
+from ayon_core.pipeline.workfile.workfile_template_builder import (
+    TemplateProfileNotFound
+)
 from ayon_core.lib import (
     Logger,
     register_event_callback,
@@ -414,11 +417,19 @@ def _create_first_workfile_from_template_timer() -> Optional[float]:
         )
         _is_opening_workfile_template = True
         create_first_workfile_from_template()
+
+    except TemplateProfileNotFound:
+        # to avoid looping of the callback, remove it!
+        log.warning("Template profile not found. Skipping...")
+        _is_opening_workfile_template = False
+
     except Exception:
         log.warning(
             "Failed to create first workfile from template on new file.",
             exc_info=True,
         )
+        _is_opening_workfile_template = False
+
     finally:
         _is_opening_workfile_template = False
 

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -70,7 +70,7 @@ ORIGINAL_EXCEPTHOOK = sys.excepthook
 
 
 log = Logger.get_logger(__name__)
-_is_opening_template = False
+_is_opening_workfile_template = False
 
 
 class BlenderHost(HostBase, IWorkfileHost, IPublishHost, ILoadHost):
@@ -411,14 +411,17 @@ def _create_first_workfile_from_template_deferred() -> Optional[float]:
         from .workfile_template_builder import (
             create_first_workfile_from_template,
         )
-        global _is_opening_template
-        _is_opening_template = True
+        global _is_opening_workfile_template
+        _is_opening_workfile_template = True
         create_first_workfile_from_template()
     except Exception:
         log.warning(
             "Failed to create first workfile from template on new file.",
             exc_info=True,
         )
+    finally:
+        _is_opening_workfile_template = False
+
     return None
 
 
@@ -514,7 +517,7 @@ def _on_load_post(*args):
         # Likely this was an open operation since it has a filepath
         emit_event("open")
     else:
-        if not _is_opening_template:
+        if not _is_opening_workfile_template:
             emit_event("new")
 
     ops.OpenFileCacher.post_load()

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -396,7 +396,7 @@ def on_new():
         _deferred_create_first_workfile_from_template()
 
 
-def _create_first_workfile_from_template_deferred() -> Optional[float]:
+def _create_first_workfile_from_template_timer() -> Optional[float]:
     """Build first workfile from template after Blender startup settles.
 
     Running this during load_post/homefile initialization can be unstable,
@@ -428,12 +428,12 @@ def _create_first_workfile_from_template_deferred() -> Optional[float]:
 def _deferred_create_first_workfile_from_template() -> None:
     """Schedule deferred first workfile template creation once."""
     if bpy.app.timers.is_registered(
-        _create_first_workfile_from_template_deferred
+        _create_first_workfile_from_template_timer
     ):
         return
 
     bpy.app.timers.register(
-        _create_first_workfile_from_template_deferred,
+        _create_first_workfile_from_template_timer,
         first_interval=0.1,
     )
 

--- a/client/ayon_blender/api/pipeline.py
+++ b/client/ayon_blender/api/pipeline.py
@@ -392,8 +392,44 @@ def on_new():
     set_unit_scale_from_settings(blender_settings=settings)
 
     if not IS_HEADLESS:
-        from .workfile_template_builder import create_first_workfile_from_template
+        _deferred_create_first_workfile_from_template()
+
+
+def _create_first_workfile_from_template_deferred() -> Optional[float]:
+    """Build first workfile from template after Blender startup settles.
+
+    Running this during load_post/homefile initialization can be unstable,
+    so defer execution and retry until context is ready.
+    """
+    window_manager = getattr(bpy.context, "window_manager", None)
+    scene = getattr(bpy.context, "scene", None)
+    if not window_manager or not scene:
+        return 0.1
+
+    try:
+        from .workfile_template_builder import (
+            create_first_workfile_from_template,
+        )
         create_first_workfile_from_template()
+    except Exception:
+        log.warning(
+            "Failed to create first workfile from template on new file.",
+            exc_info=True,
+        )
+    return None
+
+
+def _deferred_create_first_workfile_from_template() -> None:
+    """Schedule deferred first workfile template creation once."""
+    if bpy.app.timers.is_registered(
+        _create_first_workfile_from_template_deferred
+    ):
+        return
+
+    bpy.app.timers.register(
+        _create_first_workfile_from_template_deferred,
+        first_interval=0.1,
+    )
 
 
 def on_open():

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -1,6 +1,5 @@
 """Blender workfile template builder implementation"""
 import bpy
-import os
 
 import itertools
 from ayon_core.pipeline import registered_host

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -22,7 +22,6 @@ from .lib import (
     imprint,
     update_content_on_context_change
 )
-from .workio import open_file
 
 
 class BlenderTemplateBuilder(AbstractTemplateBuilder):
@@ -41,7 +40,8 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
         if not os.path.exists(path):
             self.log.warning(f"Template file not found: {path}")
             return False
-        open_file(path)
+        host = registered_host()
+        host.open_workfile(path)
         update_content_on_context_change()
         return True
 

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -40,8 +40,7 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
         if not os.path.exists(path):
             self.log.warning(f"Template file not found: {path}")
             return False
-        host = registered_host()
-        host.open_workfile(path)
+        bpy.ops.wm.read_homefile(filepath=path)
         update_content_on_context_change()
         return True
 

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -38,15 +38,9 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
         Returns:
             bool: Whether the template was successfully imported or not
         """
-        if not path:
-            self.log.debug("No workfile template path set.")
-            return False
-        if not os.path.exists(path):
-            self.log.warning(f"Workfile template file not found: {path}")
-            return False
         bpy.ops.wm.read_homefile(filepath=path)
         update_content_on_context_change()
-        return True
+
 
 class BlenderPlaceholderPlugin(PlaceholderPlugin):
     """Base Placeholder Plugin for Blender with one unified cache.

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -5,6 +5,7 @@ import os
 import itertools
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.workfile.workfile_template_builder import (
+
     AbstractTemplateBuilder,
     PlaceholderPlugin,
     PlaceholderItem,
@@ -37,6 +38,9 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
         Returns:
             bool: Whether the template was successfully imported or not
         """
+        if not path:
+            self.log.warning("No template path provided.")
+            return False
         if not os.path.exists(path):
             self.log.warning(f"Template file not found: {path}")
             return False

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -1,10 +1,10 @@
 """Blender workfile template builder implementation"""
 import bpy
+import os
 
 import itertools
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.workfile.workfile_template_builder import (
-    TemplateAlreadyImported,
     AbstractTemplateBuilder,
     PlaceholderPlugin,
     PlaceholderItem,
@@ -22,8 +22,7 @@ from .lib import (
     imprint,
     update_content_on_context_change
 )
-
-from pathlib import Path
+from .workio import open_file
 
 
 PLACEHOLDER_SET = "PLACEHOLDERS_SET"
@@ -42,32 +41,9 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
         Returns:
             bool: Whether the template was successfully imported or not
         """
-        if bpy.data.collections.get(PLACEHOLDER_SET):
-            raise TemplateAlreadyImported((
-                "Build template already loaded\n"
-                "Clean scene if needed (File > New Scene)"
-            ))
-
-        placeholder_collection = bpy.data.collections.new(PLACEHOLDER_SET)
-        bpy.context.scene.collection.children.link(placeholder_collection)
-        filepath = Path(path).resolve()
-        if not filepath.exists():
-            return False
-
-        with bpy.data.libraries.load(str(filepath)) as (data_src, data_dst):
-            data_dst.collections = data_src.collections
-            data_dst.objects = data_src.objects
-
-        # Make all paths absolute to resolve relative path warnings
-        bpy.ops.file.make_paths_absolute()
-
-        for target_object in data_dst.objects:
-            bpy.context.scene.collection.objects.link(target_object)
-        for target_collection in data_dst.collections:
-            bpy.context.scene.collection.children.link(target_collection)
-
-
-        # update imported sets information
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Template file not found: {path}")
+        open_file(path)
         update_content_on_context_change()
         return True
 

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -42,7 +42,7 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
             self.log.debug("No workfile template path set.")
             return False
         if not os.path.exists(path):
-            self.log.warning(f"Template file not found: {path}")
+            self.log.warning(f"Workfile template file not found: {path}")
             return False
         bpy.ops.wm.read_homefile(filepath=path)
         update_content_on_context_change()

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -5,7 +5,6 @@ import itertools
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.workfile.workfile_template_builder import (
     TemplateProfileNotFound,
-    TemplateLoadFailed,
     AbstractTemplateBuilder,
     PlaceholderPlugin,
     PlaceholderItem,
@@ -197,11 +196,6 @@ def create_first_workfile_from_template() -> None:
         log.warning(
             "Template profile not found. Skipping..."
         )
-
-    except TemplateLoadFailed:
-        log.warning(
-            "Template path not set. Skipping..."
-    )
 
 
 def build_workfile_template(*args) -> None:

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -37,8 +37,6 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
             path (str): A path to current template (usually given by
             get_template_preset implementation)
 
-        Returns:
-            bool: Whether the template was successfully imported or not
         """
         bpy.ops.wm.read_homefile(filepath=path)
         update_content_on_context_change()

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -1,10 +1,10 @@
 """Blender workfile template builder implementation"""
 import bpy
-
+import logging
 import itertools
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.workfile.workfile_template_builder import (
-
+    TemplateProfileNotFound,
     AbstractTemplateBuilder,
     PlaceholderPlugin,
     PlaceholderItem,
@@ -22,6 +22,9 @@ from .lib import (
     imprint,
     update_content_on_context_change
 )
+
+
+log = logging.getLogger(__name__)
 
 
 class BlenderTemplateBuilder(AbstractTemplateBuilder):
@@ -186,7 +189,10 @@ def set_folder_path_for_ayon_instances(folder_path: str) -> None:
 def create_first_workfile_from_template(*args) -> None:
     """Create the first workfile from template for Blender."""
     builder = BlenderTemplateBuilder(registered_host())
-    builder.build_template(workfile_creation_enabled=True)
+    try:
+        builder.build_template(workfile_creation_enabled=True)
+    except TemplateProfileNotFound:
+        log.warning("Template profile not found. Skipping...")
 
 
 def build_workfile_template(*args) -> None:

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -39,7 +39,8 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
             bool: Whether the template was successfully imported or not
         """
         if not os.path.exists(path):
-            raise FileNotFoundError(f"Template file not found: {path}")
+            self.log.warning(f"Template file not found: {path}")
+            return False
         open_file(path)
         update_content_on_context_change()
         return True

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -39,7 +39,7 @@ class BlenderTemplateBuilder(AbstractTemplateBuilder):
             bool: Whether the template was successfully imported or not
         """
         if not path:
-            self.log.warning("No template path provided.")
+            self.log.debug("No workfile template path set.")
             return False
         if not os.path.exists(path):
             self.log.warning(f"Template file not found: {path}")

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -25,9 +25,6 @@ from .lib import (
 from .workio import open_file
 
 
-PLACEHOLDER_SET = "PLACEHOLDERS_SET"
-
-
 class BlenderTemplateBuilder(AbstractTemplateBuilder):
     """Concrete implementation of AbstractTemplateBuilder for Blender"""
     def import_template(self, path):
@@ -147,27 +144,6 @@ class BlenderPlaceholderPlugin(PlaceholderPlugin):
             )
 
         return placeholders
-
-    def post_placeholder_process(self, placeholder, failed):
-        """Cleanup placeholder after load of its corresponding representations.
-
-        Hide placeholder, add them to placeholder set.
-        Used only by PlaceholderCreateMixin and PlaceholderLoadMixin
-
-        Args:
-            placeholder (PlaceholderItem): Item which was just used to load
-                representation.
-            failed (bool): Loading of representation failed.
-        """
-        # Hide placeholder and add them to placeholder set
-        node = placeholder.scene_identifier
-
-        # If we just populate the placeholders from current scene, the
-        # placeholder set will not be created so account for that.
-        placeholder_set = bpy.data.collections.get(PLACEHOLDER_SET)
-        if placeholder_set:
-            placeholder_set = bpy.data.collections.new(name=PLACEHOLDER_SET)
-        placeholder_set.children = node
 
     def delete_placeholder(self, placeholder):
         """Remove placeholder if building was successful

--- a/client/ayon_blender/api/workfile_template_builder.py
+++ b/client/ayon_blender/api/workfile_template_builder.py
@@ -5,6 +5,7 @@ import itertools
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.workfile.workfile_template_builder import (
     TemplateProfileNotFound,
+    TemplateLoadFailed,
     AbstractTemplateBuilder,
     PlaceholderPlugin,
     PlaceholderItem,
@@ -186,13 +187,21 @@ def set_folder_path_for_ayon_instances(folder_path: str) -> None:
         imprint(obj_or_col, {"folderPath": folder_path})
 
 
-def create_first_workfile_from_template(*args) -> None:
+def create_first_workfile_from_template() -> None:
     """Create the first workfile from template for Blender."""
     builder = BlenderTemplateBuilder(registered_host())
     try:
         builder.build_template(workfile_creation_enabled=True)
+
     except TemplateProfileNotFound:
-        log.warning("Template profile not found. Skipping...")
+        log.warning(
+            "Template profile not found. Skipping..."
+        )
+
+    except TemplateLoadFailed:
+        log.warning(
+            "Template path not set. Skipping..."
+    )
 
 
 def build_workfile_template(*args) -> None:


### PR DESCRIPTION
## Changelog Description
This PR is to add support for automatically creating the first workfile if templated workfile build in addon setting is provided.

## Additional review information
Resolves https://github.com/ynput/ayon-blender/issues/308

## Testing notes:
1. Set up your path for your template and set `create first workfile` to True in `ayon+settings://blender/templated_workfile_build/profiles`
2. Launch Blender with the task which has not yet created any workfile
3. It will automatically open and save the template file as the first workfile
