### PR TITLE
Blender 5.2+ compatibility fixes

### DIFF
--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -1007,11 +1007,11 @@ def iter_bpy_prop_collection_idprop():
         if not isinstance(prop, bpy.types.bpy_prop_collection):
             continue
 
-        # Check if this is bpy_prop_collection_idprop by checking for all
-        # for an attributes this base class should expose that does not live
+        # Check if this is `bpy_prop_collection_idprop` by checking for an
+        # attribute this base class should expose that does not live
         # on bpy_prop_collection. In Blender 5.2+ `bpy.data.all_ids` attribute
         # was added which is a `bpy_prop_collection` but does not come with
-        # the `remove` method for example.
+        # the `remove` method for example which we want to skip here.
         if not hasattr(prop, "remove"):
             continue
 

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -1,22 +1,17 @@
+import contextlib
 import hashlib
+import importlib
 import os
 import traceback
-import importlib
-import contextlib
 from typing import Dict, List, Union
 
-import bpy
 import addon_utils
-from ayon_core.lib import (
-    Logger,
-    NumberDef
-)
+import bpy
+from ayon_core.lib import Logger, NumberDef
 from ayon_core.pipeline import registered_host
-
 from ayon_core.pipeline.create import CreateContext
 
 from . import pipeline
-
 from .constants import AYON_PROPERTY
 
 log = Logger.get_logger(__name__)
@@ -998,6 +993,29 @@ def update_content_on_context_change():
 
     if has_changes:
         create_context.save_changes()
+
+
+def iter_bpy_prop_collection_idprop():
+    """Iterate over all blender property collections.
+
+    See:
+        https://docs.blender.org/api/current/bpy.types.bpy_prop_collection_idprop.html
+    """ # noqa
+    data = bpy.data
+    for attr in dir(data):
+        prop = getattr(data, attr)
+        if not isinstance(prop, bpy.types.bpy_prop_collection):
+            continue
+
+        # Check if this is bpy_prop_collection_idprop by checking for all
+        # for an attributes this base class should expose that does not live
+        # on bpy_prop_collection. In Blender 5.2+ `bpy.data.all_ids` attribute
+        # was added which is a `bpy_prop_collection` but does not come with
+        # the `remove` method for example.
+        if not hasattr(prop, "remove"):
+            continue
+
+        yield attr, prop
 
 
 def clean_filename(filename: str) -> str:

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -996,7 +996,7 @@ def update_content_on_context_change():
 
 
 def iter_bpy_prop_collection_idprop():
-    """Iterate over all blender property collections.
+    """Iterate over all Blender property collections.
 
     See:
         https://docs.blender.org/api/current/bpy.types.bpy_prop_collection_idprop.html

--- a/client/ayon_blender/api/render_lib.py
+++ b/client/ayon_blender/api/render_lib.py
@@ -138,7 +138,7 @@ def set_render_passes(settings, renderer, view_layers):
         aov_list = base_aov_list.union(existing_aov_list)
         aov_list_combined.update(aov_list)
 
-        if renderer == "BLENDER_EEVEE":
+        if _is_legacy_eevee_renderer(renderer):
             # Eevee exclusive passes
             aov_options = get_aov_options(renderer)
             eevee_attrs: set[str] = {
@@ -178,6 +178,29 @@ def set_render_passes(settings, renderer, view_layers):
     return list(aov_list_combined), custom_passes
 
 
+def _is_legacy_eevee_renderer(renderer):
+    """Return whether renderer is Eevee in Blender lower than 4.2.
+
+    Note:
+      In Blender <4.2 'BLENDER_EEVEE' represents Eevee renderer.
+      In Blender 4.2-5.1 'BLENDER_EEVEE_NEXT' represents Eevee renderer.
+      In Blender >5.2 'BLENDER_EEVEE' represents Eevee renderer.
+
+    Args:
+        renderer (str): Renderer name.
+
+    Returns:
+        bool: Whether renderer is Eevee in Blender version lower than 4.2.
+    """
+    if renderer != "BLENDER_EEVEE":
+        return False
+
+    ver_major, ver_minor, _ = lib.get_blender_version()
+    if (ver_major, ver_minor) < (4, 2):
+        return True
+    return False
+
+
 def get_aov_options(renderer: str) -> dict[str, str]:
     """Return the available AOV options based on the renderer name."""
     aov_options = {
@@ -196,7 +219,7 @@ def get_aov_options(renderer: str) -> dict[str, str]:
         "cryptomatte_material": "use_pass_cryptomatte_material",
         "cryptomatte_asset": "use_pass_cryptomatte_asset",
     }
-    if renderer == "BLENDER_EEVEE":
+    if _is_legacy_eevee_renderer(renderer):
         eevee_options = {
             "shadow": "use_pass_shadow",
             "volume_light": "use_pass_volume_direct",
@@ -233,7 +256,7 @@ def existing_aov_options(
 ) -> list[str]:
     aov_list = []
     aov_options = get_aov_options(renderer)
-    if renderer == "BLENDER_EEVEE":
+    if _is_legacy_eevee_renderer(renderer):
         eevee_attrs = ["use_pass_shadow", "cryptomatte_accurate"]
         for pass_name, attr in aov_options.items():
             target = view_layer.eevee if attr in eevee_attrs else view_layer
@@ -538,8 +561,10 @@ def prepare_rendering(
     multilayer = get_multilayer(project_settings)
     renderer = get_renderer(project_settings)
     ver_major, ver_minor, _ = lib.get_blender_version()
+
+    # Between Blender 4.2 and 5.1, the Eevee renderer is BLENDER_EEVEE_NEXT
     if renderer == "BLENDER_EEVEE" and (
-        ver_major >= 4 and ver_minor >=2
+        (4, 2) <= (ver_major, ver_minor) <= (5, 1)
     ):
         renderer = "BLENDER_EEVEE_NEXT"
 

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -87,6 +87,7 @@ class CreateRender(plugin.BlenderCreator):
                 view_layer_nodes,
                 project_settings
             )
+            return
 
         project_name = self.create_context.get_current_project_name()
         project_entity = self.create_context.get_current_project_entity()

--- a/client/ayon_blender/plugins/create/create_render.py
+++ b/client/ayon_blender/plugins/create/create_render.py
@@ -87,7 +87,6 @@ class CreateRender(plugin.BlenderCreator):
                 view_layer_nodes,
                 project_settings
             )
-            return
 
         project_name = self.create_context.get_current_project_name()
         project_entity = self.create_context.get_current_project_entity()

--- a/client/ayon_blender/plugins/load/load_blend.py
+++ b/client/ayon_blender/plugins/load/load_blend.py
@@ -11,6 +11,7 @@ from ayon_blender.api.lib import (
     get_blender_version,
     create_animation_instance,
     clean_filename,
+    iter_bpy_prop_collection_idprop,
 )
 from ayon_blender.api.pipeline import (
     add_to_ayon_container,
@@ -294,14 +295,6 @@ class BlendLoader(plugin.BlenderLoader):
         group_name = container["objectName"]
         asset_group = bpy.data.objects.get(group_name)
 
-        attrs = [
-            attr for attr in dir(bpy.data)
-            if isinstance(
-                getattr(bpy.data, attr),
-                bpy.types.bpy_prop_collection
-            )
-        ]
-
         members = asset_group.get(AYON_PROPERTY).get("members", [])
 
         # We need to update all the parent container members
@@ -312,12 +305,12 @@ class BlendLoader(plugin.BlenderLoader):
                 lambda i: i not in members,
                 parent.get(AYON_PROPERTY).get("members", [])))
 
-        for attr in attrs:
-            for data in getattr(bpy.data, attr):
-                if data in members:
-                    # Skip the asset group
-                    if data == asset_group:
+        if members:
+            for _, attr in iter_bpy_prop_collection_idprop():
+                # make a list copy because we remove members as we iterate
+                for data in list(attr):
+                    if data not in members or data == asset_group:
                         continue
-                    getattr(bpy.data, attr).remove(data)
+                    attr.remove(data)
 
         bpy.data.objects.remove(asset_group)

--- a/client/ayon_blender/plugins/load/load_blendscene.py
+++ b/client/ayon_blender/plugins/load/load_blendscene.py
@@ -10,6 +10,7 @@ from ayon_blender.api.lib import (
     imprint,
     get_blender_version,
     clean_filename,
+    iter_bpy_prop_collection_idprop,
 )
 from ayon_blender.api.constants import (
     AYON_CONTAINERS,
@@ -228,17 +229,11 @@ class BlendSceneLoader(plugin.BlenderLoader):
         members = set(asset_group.get(AYON_PROPERTY).get("members", []))
 
         if members:
-            for attr_name in dir(bpy.data):
-                attr = getattr(bpy.data, attr_name)
-                if not isinstance(attr, bpy.types.bpy_prop_collection):
-                    continue
-
-                # ensure to make a list copy because we
-                # we remove members as we iterate
+            for _, attr in iter_bpy_prop_collection_idprop():
+                # make a list copy because we remove members as we iterate
                 for data in list(attr):
                     if data not in members or data == asset_group:
                         continue
-
                     attr.remove(data)
 
         bpy.data.collections.remove(asset_group)


### PR DESCRIPTION
## Changelog Description

Blender 5.2 should work correctly within AYON.

## Additional review information

1. Avoid error:
```python
Traceback (most recent call last):

  File "C:\Users\lbate\AppData\Local\Ynput\AYON\addons\blender_1.1.6\ayon_blender\api\ops.py", line 126, in execute
    result = callback(*args, **kwargs)

  File "C:\Users\lbate\AppData\Local\Ynput\AYON\addons\blender_1.1.6\ayon_blender\plugins\load\load_blend.py", line 237, in exec_update
    self.exec_remove(container)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^

  File "C:\Users\lbate\AppData\Local\Ynput\AYON\addons\blender_1.1.6\ayon_blender\plugins\load\load_blend.py", line 321, in exec_remove
    getattr(bpy.data, attr).remove(data)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

AttributeError: bpy_prop_collection: attribute "remove" not found
```

2. Also fix error with `BLENDER_EEVEE_NEXT` found found in render engine enum because it's renamed back to `BLENDER_EEVEE`

Please do more testing an report any issues.
Create issues for those things that we need to add additional support for in Blender 5.2+ (e.g. new features)

## Testing notes:

1. Blender 5.2 should work as intended.