### PR TITLE
Review: Capture Preset per profile

### DIFF
--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -24,7 +24,7 @@ def capture(
     camera_options=None,
     resolution=None,
     log=None,
-):
+)-> str:
     """Playblast in an independent windows
     Arguments:
         camera (str, optional): Name of camera, defaults to "Camera"
@@ -199,7 +199,6 @@ def applied_view(
     space = area.spaces[0]
     space.shading.render_pass = "COMBINED"
 
-    types = {"MESH", "GPENCIL", "CAMERA"}
     types = {"MESH", "GPENCIL", "CAMERA"}
     objects = [obj for obj in window.scene.objects if obj.type in types]
 

--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -197,6 +197,7 @@ def applied_view(
     area = window.screen.areas[0]
     area.ui_type = "VIEW_3D"
     space = area.spaces[0]
+    space.shading.render_pass = "COMBINED"
 
     types = {"MESH", "GPENCIL", "CAMERA"}
     objects = [obj for obj in window.scene.objects if obj.type in types]

--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -11,8 +11,6 @@ from .plugin import deselect_all, create_blender_context
 
 def capture(
     camera=None,
-    width=None,
-    height=None,
     filename=None,
     start_frame=None,
     end_frame=None,
@@ -22,13 +20,14 @@ def capture(
     maintain_aspect_ratio=True,
     overwrite=False,
     image_settings=None,
-    display_options=None
+    display_options=None,
+    camera_options=None,
+    resolution=None,
+    log=None,
 ):
     """Playblast in an independent windows
     Arguments:
         camera (str, optional): Name of camera, defaults to "Camera"
-        width (int, optional): Width of output in pixels
-        height (int, optional): Height of output in pixels
         filename (str, optional): Name of output file path. Defaults to current
             render output path.
         start_frame (int, optional): Defaults to current start frame.
@@ -45,6 +44,12 @@ def capture(
         image_settings (dict, optional): Supplied image settings for render,
             using `ImageSettings`
         display_options (dict, optional): Supplied display options for render
+            using `DisplayOptions`
+        camera_options (dict, optional): Supplied camera options for render
+            using `CameraOptions`
+        resolution (dict, optional): Supplied resolution settings for render,
+            using `ResolutionSetting`
+        log (logging.Logger, optional): Logger for capturing process.
     """
 
     scene = bpy.context.scene
@@ -55,10 +60,13 @@ def capture(
         raise RuntimeError("Camera does not exist: {0}".format(camera))
 
     # Ensure resolution.
-    if width and height:
-        maintain_aspect_ratio = False
-    width = width or scene.render.resolution_x
-    height = height or scene.render.resolution_y
+    width = resolution.get("width", 0)
+    if width == 0:
+        width = scene.render.resolution_x
+    height = resolution.get("height", 0)
+    if height == 0:
+        height = scene.render.resolution_y
+    maintain_aspect_ratio = resolution.get("maintain_aspect_ratio", True)
     if maintain_aspect_ratio:
         ratio = scene.render.resolution_x / scene.render.resolution_y
         height = round(width / ratio)
@@ -88,10 +96,19 @@ def capture(
 
     with _independent_window() as window:
 
-        applied_view(window, camera, isolate, options=display_options)
+        applied_view(
+            window,
+            camera,
+            isolate,
+            display_options=display_options,
+            camera_options=camera_options,
+            log=log
+        )
 
         with contextlib.ExitStack() as stack:
-            stack.enter_context(maintain_camera(window, camera))
+            stack.enter_context(
+                maintain_camera_settings(window, camera, camera_options=camera_options)
+            )
             stack.enter_context(applied_frame_range(window, *frame_range))
             stack.enter_context(applied_render_options(window, render_options))
             stack.enter_context(applied_image_settings(window, image_settings))
@@ -140,13 +157,14 @@ def isolate_objects(window, objects):
 
     deselect_all()
 
+
 def restore_global_view(window):
     """Exit local view if active.
 
     Blender currently does not exit localview when closing windows.
     """
 
-    types = {"MESH", "GPENCIL"}
+    types = {"MESH", "GPENCIL", "CAMERA"}
     objects = [obj for obj in window.scene.objects if obj.type in types]
 
     context = create_blender_context(selected=objects, window=window)
@@ -155,7 +173,8 @@ def restore_global_view(window):
         # Only toggle back if in local view
         if bpy.context.space_data.local_view:
             bpy.ops.view3d.localview()
-    
+
+
 def _apply_options(entity, options):
     for option, value in options.items():
         if isinstance(value, dict):
@@ -164,13 +183,20 @@ def _apply_options(entity, options):
             setattr(entity, option, value)
 
 
-def applied_view(window, camera, isolate=None, options=None):
+def applied_view(
+        window,
+        camera,
+        isolate=None,
+        display_options=None,
+        camera_options=None,
+        log=None
+    ):
     """Apply view options to window."""
     area = window.screen.areas[0]
     area.ui_type = "VIEW_3D"
     space = area.spaces[0]
 
-    types = {"MESH", "GPENCIL"}
+    types = {"MESH", "GPENCIL", "CAMERA"}
     objects = [obj for obj in window.scene.objects if obj.type in types]
 
     if camera == "AUTO":
@@ -181,13 +207,19 @@ def applied_view(window, camera, isolate=None, options=None):
         space.camera = window.scene.objects.get(camera)
         space.region_3d.view_perspective = "CAMERA"
 
-    if isinstance(options, dict):
-        _apply_options(space, options)
+    if isinstance(display_options, dict):
+        _apply_options(space, display_options)
+    # This would be removed after the transition
+    # of the new capture preset
     else:
         space.shading.type = "SOLID"
         space.shading.color_type = "MATERIAL"
         space.show_gizmo = False
         space.overlay.show_overlays = False
+
+    if camera_options.get("background_images"):
+        log.warning("Overlay visibility must be enabled to display background images (image planes).")
+        space.overlay.show_overlays = True
 
 
 @contextlib.contextmanager
@@ -284,15 +316,25 @@ def applied_image_settings(window, options):
 
 
 @contextlib.contextmanager
-def maintain_camera(window, camera):
+def maintain_camera_settings(window, camera, camera_options=None):
     """Context manager to override camera."""
     current_camera = window.scene.camera
-    if camera in window.scene.objects:
-        window.scene.camera = window.scene.objects.get(camera)
+    target_camera = window.scene.objects.get(camera)
+    current_image_plane = None
+    if target_camera:
+        window.scene.camera = target_camera
+        if hasattr(target_camera.data, "show_background_images"):
+            current_image_plane = target_camera.data.show_background_images
+            target_camera.data.show_background_images = camera_options.get(
+                "show_background_images", current_image_plane
+            )
     try:
         yield
     finally:
         window.scene.camera = current_camera
+        if target_camera and current_image_plane is not None:
+            target_camera.data.show_background_images = current_image_plane
+
 
 
 @contextlib.contextmanager

--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -217,8 +217,12 @@ def applied_view(
         space.show_gizmo = False
         space.overlay.show_overlays = False
 
+    camera_options = camera_options or {}
     if camera_options.get("background_images"):
-        log.warning("Overlay visibility must be enabled to display background images (image planes).")
+        if log:
+            log.warning(
+                "Overlay visibility must be enabled to display background images (image planes)."
+            )
         space.overlay.show_overlays = True
 
 

--- a/client/ayon_blender/api/capture.py
+++ b/client/ayon_blender/api/capture.py
@@ -17,7 +17,7 @@ def capture(
     step_frame=None,
     sound=None,
     isolate=None,
-    maintain_aspect_ratio=True,
+    maintain_aspect_ratio=None,
     overwrite=False,
     image_settings=None,
     display_options=None,
@@ -36,8 +36,8 @@ def capture(
         sound (str, optional):  Specify the sound node to be used during
             playblast. When None (default) no sound will be used.
         isolate (list): List of nodes to isolate upon capturing
-        maintain_aspect_ratio (bool, optional): Modify height in order to
-            maintain aspect ratio.
+        maintain_aspect_ratio (bool, optional): Override whether to modify
+            height to maintain aspect ratio.
         overwrite (bool, optional): Whether or not to overwrite if file
             already exists. If disabled and file exists and error will be
             raised.
@@ -60,13 +60,15 @@ def capture(
         raise RuntimeError("Camera does not exist: {0}".format(camera))
 
     # Ensure resolution.
+    resolution = resolution or {}
     width = resolution.get("width", 0)
     if width == 0:
         width = scene.render.resolution_x
     height = resolution.get("height", 0)
     if height == 0:
         height = scene.render.resolution_y
-    maintain_aspect_ratio = resolution.get("maintain_aspect_ratio", True)
+    if maintain_aspect_ratio is None:
+        maintain_aspect_ratio = resolution.get("maintain_aspect_ratio", True)
     if maintain_aspect_ratio:
         ratio = scene.render.resolution_x / scene.render.resolution_y
         height = round(width / ratio)
@@ -322,6 +324,7 @@ def applied_image_settings(window, options):
 @contextlib.contextmanager
 def maintain_camera_settings(window, camera, camera_options=None):
     """Context manager to override camera."""
+    camera_options = camera_options or {}
     current_camera = window.scene.camera
     target_camera = window.scene.objects.get(camera)
     current_image_plane = None
@@ -330,7 +333,7 @@ def maintain_camera_settings(window, camera, camera_options=None):
         if hasattr(target_camera.data, "show_background_images"):
             current_image_plane = target_camera.data.show_background_images
             target_camera.data.show_background_images = camera_options.get(
-                "show_background_images", current_image_plane
+                "background_images", current_image_plane
             )
     try:
         yield
@@ -338,7 +341,6 @@ def maintain_camera_settings(window, camera, camera_options=None):
         window.scene.camera = current_camera
         if target_camera and current_image_plane is not None:
             target_camera.data.show_background_images = current_image_plane
-
 
 
 @contextlib.contextmanager

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -1,6 +1,9 @@
 import contextlib
 import hashlib
 import importlib
+import json
+import logging
+import copy
 import os
 import traceback
 from typing import Dict, List, Union
@@ -10,6 +13,7 @@ import bpy
 from ayon_core.lib import Logger, NumberDef
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.create import CreateContext
+from ayon_core.lib.profiles_filtering import filter_profiles
 
 from . import pipeline
 from .constants import AYON_PROPERTY
@@ -1030,3 +1034,52 @@ def clean_filename(filename: str) -> str:
     """
     digest = hashlib.sha1(filename.encode("utf-8")).hexdigest()[:8]
     return f"{filename[:54]}_{digest}"
+
+
+def get_capture_preset(
+    task_name: str,
+    task_type: str,
+    product_name: str,
+    project_settings: dict,
+    log: "logging.Logger"
+) -> dict:
+    """Get capture preset for playblasting.
+
+    Logic for transitioning from old style capture preset to new capture preset
+    profiles.
+
+    Args:
+        task_name (str): Task name.
+        task_type (str): Task type.
+        product_name (str): Product name.
+        project_settings (dict): Project settings.
+        log (logging.Logger): Logging object.
+    Returns:
+        dict: The capture preset for playblasting.
+    """
+    capture_preset = None
+    filtering_criteria = {
+        "task_names": task_name,
+        "task_types": task_type,
+        "product_names": product_name
+    }
+
+    plugin_settings = project_settings["blender"]["publish"]["ExtractPlayblast"]
+    if plugin_settings["profiles"]:
+        profile = filter_profiles(
+            plugin_settings["profiles"],
+            filtering_criteria,
+            logger=log
+        ) or {}
+        presets = profile.get("presets")
+        capture_preset = copy.deepcopy(presets)
+        capture_preset["image_settings"]["file_format"] = (
+            capture_preset["image_settings"]["file_format"].upper()
+        )
+        log.warning("No profiles present for Extract Playblast")
+    if capture_preset is None:
+        log.warning("Fallback to backward compatible capture preset.")
+        serialized_preset = json.loads(plugin_settings.get("presets", "{}"))
+        capture_preset = serialized_preset.get("default")
+
+    return capture_preset or {}

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -1065,21 +1065,32 @@ def get_capture_preset(
     }
 
     plugin_settings = project_settings["blender"]["publish"]["ExtractPlayblast"]
-    if plugin_settings["profiles"]:
+
+    profiles = plugin_settings.get("profiles") or []
+    if profiles:
         profile = filter_profiles(
-            plugin_settings["profiles"],
-            filtering_criteria,
+            profiles,
+            key_values=filtering_criteria,
             logger=log
         ) or {}
-        presets = profile.get("presets")
-        capture_preset = copy.deepcopy(presets)
-        capture_preset["image_settings"]["file_format"] = (
-            capture_preset["image_settings"]["file_format"].upper()
+        presets = profile.get("presets") or {}
+        if presets:
+            capture_preset = copy.deepcopy(presets)
+            image_settings = capture_preset.get("image_settings") or {}
+            if image_settings.get("file_format"):
+                image_settings["file_format"] = image_settings["file_format"].upper()
+            capture_preset["image_settings"] = image_settings
+        else:
+            log.warning(
+                "No matching playblast profile found; falling back to deprecated presets."
+            )
+    else:
+        log.warning(
+            "No profiles present for Extract Playblast; falling back to deprecated presets."
         )
-        log.warning("No profiles present for Extract Playblast")
+
     if capture_preset is None:
         log.warning("Fallback to backward compatible capture preset.")
         serialized_preset = json.loads(plugin_settings.get("presets", "{}"))
         capture_preset = serialized_preset.get("default")
-
     return capture_preset or {}

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -1040,11 +1040,13 @@ def get_capture_preset(
     task_name: str,
     task_type: str,
     product_name: str,
+    product_base_type: str,
     project_settings: dict,
-    log: "logging.Logger"
+    class_name: str,
+    log: "logging.Logger",
 ) -> dict:
     """Get capture preset for playblasting.
-
+    If `product_base_type` is provided, it will be used as an additional filtering criterion.
     Logic for transitioning from old style capture preset to new capture preset
     profiles.
 
@@ -1052,6 +1054,7 @@ def get_capture_preset(
         task_name (str): Task name.
         task_type (str): Task type.
         product_name (str): Product name.
+        product_base_type (str): Product base type.
         project_settings (dict): Project settings.
         log (logging.Logger): Logging object.
     Returns:
@@ -1061,11 +1064,12 @@ def get_capture_preset(
     filtering_criteria = {
         "task_names": task_name,
         "task_types": task_type,
-        "product_names": product_name
+        "product_names": product_name,
+        "product_base_types": product_base_type
     }
 
-    plugin_settings = project_settings["blender"]["publish"]["ExtractPlayblast"]
-
+    plugin_settings = project_settings["blender"]["publish"][class_name]
+    # Get profiles from plugin settings
     profiles = plugin_settings.get("profiles") or []
     if profiles:
         profile = filter_profiles(
@@ -1080,6 +1084,8 @@ def get_capture_preset(
             if image_settings.get("file_format"):
                 image_settings["file_format"] = image_settings["file_format"].upper()
             capture_preset["image_settings"] = image_settings
+            capture_preset = add_additional_presets(capture_preset)
+
         else:
             log.warning(
                 "No matching playblast profile found; falling back to deprecated presets."
@@ -1089,8 +1095,70 @@ def get_capture_preset(
             "No profiles present for Extract Playblast; falling back to deprecated presets."
         )
 
+    # backward compatible fallback for capture preset
     if capture_preset is None:
         log.warning("Fallback to backward compatible capture preset.")
         serialized_preset = json.loads(plugin_settings.get("presets", "{}"))
-        capture_preset = serialized_preset.get("default")
+        if class_name == "ExtractPlayblast":
+            capture_preset = serialized_preset.get("default")
+        elif class_name == "ExtractThumbnail":
+            capture_preset = serialized_preset.get(product_base_type)
+        else:
+            raise RuntimeError(f"Unsupported class_name: {class_name}")
+
     return capture_preset or {}
+
+
+def add_additional_presets(capture_preset: dict) -> dict:
+    """Update additonal presets as settings in Playblast if there is any.
+    e.g.
+        capture_preset = {
+            "display_options":  {
+                "shading": {
+                    "light": "STUDIO",
+                    "studio_light": "Default",
+                    "type": "SOLID",
+                    "color_type": "OBJECT",
+                    "show_xray": True,
+                    "show_shadows": False,
+                    "show_cavity": False
+                },
+              "overlay": {
+              ....
+              }
+            }
+            ....
+            "additional_presets": {
+                "display_options": {
+                    "shading": {
+                        "show_xray_wireframe": True
+                    }
+                }
+            }
+        }
+        updated_preset = add_additional_presets(capture_preset)
+        # updated_preset will now include the "compression" setting from additional_presets
+
+    Args:
+        capture_preset (dict): capture preset dictionary containing playblast settings.
+
+    Returns:
+        dict: Updated capture preset with additional presets applied.
+    """
+    additonal_presets = capture_preset.get("additional_presets", "{}")
+    if additonal_presets:
+        presets = json.loads(additonal_presets)
+        if not presets:
+            return capture_preset
+
+        for key, value in presets.items():
+            if (
+                key in capture_preset
+                and isinstance(capture_preset[key], dict)
+                and isinstance(value, dict)
+            ):
+                capture_preset[key].update(value)
+            else:
+                capture_preset[key] = value
+
+    return capture_preset

--- a/client/ayon_blender/api/lib.py
+++ b/client/ayon_blender/api/lib.py
@@ -1145,7 +1145,7 @@ def add_additional_presets(capture_preset: dict) -> dict:
     Returns:
         dict: Updated capture preset with additional presets applied.
     """
-    additonal_presets = capture_preset.get("additional_presets", "{}")
+    additonal_presets = capture_preset.pop("additional_presets", None)
     if additonal_presets:
         presets = json.loads(additonal_presets)
         if not presets:

--- a/client/ayon_blender/plugins/publish/collect_review.py
+++ b/client/ayon_blender/plugins/publish/collect_review.py
@@ -34,7 +34,7 @@ class CollectReview(plugin.BlenderInstancePlugin):
         focal_length = cameras[0].data.lens
 
         # get isolate objects list from meshes instance members.
-        types = {"MESH", "GPENCIL"}
+        types = {"MESH", "GPENCIL", "CAMERA"}
         isolate_objects = [
             obj
             for obj in instance

--- a/client/ayon_blender/plugins/publish/extract_playblast.py
+++ b/client/ayon_blender/plugins/publish/extract_playblast.py
@@ -68,7 +68,7 @@ class ExtractPlayblast(
             product_name=instance.data["productName"],
             product_base_type=instance.data["productBaseType"],
             project_settings=instance.context.data["project_settings"],
-            class_name=self.__name__,
+            class_name=self.__class__.__name__,
             log=self.log
         )
         # additional required parameters for playblast

--- a/client/ayon_blender/plugins/publish/extract_playblast.py
+++ b/client/ayon_blender/plugins/publish/extract_playblast.py
@@ -1,5 +1,4 @@
 import os
-import json
 
 import clique
 import pyblish.api

--- a/client/ayon_blender/plugins/publish/extract_playblast.py
+++ b/client/ayon_blender/plugins/publish/extract_playblast.py
@@ -100,9 +100,13 @@ class ExtractPlayblast(
 
         collected_files = os.listdir(stagingdir)
         extension = preset["image_settings"].get("file_format", "PNG").lower()
+        extension_pattern = "jpeg" if extension == "jpeg" else extension
         collections, _remainder = clique.assemble(
             collected_files,
-            patterns=[f"{filename}\\.{clique.DIGITS_PATTERN}\\.{extension}$"],
+            patterns=[
+                f"{filename}\\.{clique.DIGITS_PATTERN}\\."
+                f"{extension_pattern}$"
+            ],
             minimum_items=1
         )
 
@@ -121,6 +125,7 @@ class ExtractPlayblast(
 
         # `instance.data["files"]` must be `str` if single frame
         files = list(frame_collection)
+        extension = os.path.splitext(files[0])[1].lstrip(".").lower()
         if len(files) == 1:
             files = files[0]
 

--- a/client/ayon_blender/plugins/publish/extract_playblast.py
+++ b/client/ayon_blender/plugins/publish/extract_playblast.py
@@ -8,7 +8,7 @@ import bpy
 
 from ayon_core.pipeline import publish
 from ayon_blender.api import capture, plugin
-from ayon_blender.api.lib import maintained_time
+from ayon_blender.api.lib import maintained_time, get_capture_preset
 
 
 class ExtractPlayblast(
@@ -26,8 +26,6 @@ class ExtractPlayblast(
     families = ["review.playblast"]
     optional = True
     order = pyblish.api.ExtractorOrder + 0.01
-
-    presets = "{}"
 
     def process(self, instance):
         if not self.is_active(instance.data):
@@ -64,9 +62,15 @@ class ExtractPlayblast(
         path = os.path.join(stagingdir, filename)
 
         self.log.debug(f"Outputting images to {path}")
-
-        presets = json.loads(self.presets)
-        preset = presets.get("default")
+        task_data = instance.data["anatomyData"].get("task", {})
+        preset = get_capture_preset(
+            task_data.get("name"),
+            task_data.get("type"),
+            instance.data["productName"],
+            instance.context.data["project_settings"],
+            log=self.log
+        )
+        # additional required parameters for playblast
         preset.update({
             "camera": camera,
             "start_frame": start,
@@ -74,16 +78,20 @@ class ExtractPlayblast(
             "filename": path,
             "overwrite": True,
             "isolate": isolate,
+            "log": self.log
         })
-        preset.setdefault(
-            "image_settings",
-            {
-                "file_format": "PNG",
-                "color_mode": "RGB",
-                "color_depth": "8",
-                "compression": 15,
-            },
-        )
+        # This would be removed after the transition of
+        # the new capture preset system.
+        if not preset.get("image_settings"):
+            preset.setdefault(
+                "image_settings",
+                {
+                    "file_format": "PNG",
+                    "color_mode": "RGB",
+                    "color_depth": "8",
+                    "compression": 15,
+                },
+            )
 
         with maintained_time():
             path = capture(**preset)
@@ -92,9 +100,10 @@ class ExtractPlayblast(
         self._maintain_publisher_focus()
 
         collected_files = os.listdir(stagingdir)
-        collections, remainder = clique.assemble(
+        extension = preset["image_settings"].get("file_format", "PNG").lower()
+        collections, _remainder = clique.assemble(
             collected_files,
-            patterns=[f"{filename}\\.{clique.DIGITS_PATTERN}\\.png$"],
+            patterns=[f"{filename}\\.{clique.DIGITS_PATTERN}\\.{extension}$"],
             minimum_items=1
         )
 
@@ -121,8 +130,8 @@ class ExtractPlayblast(
             tags.append("delete")
 
         representation = {
-            "name": "png",
-            "ext": "png",
+            "name": extension,
+            "ext": extension,
             "files": files,
             "stagingDir": stagingdir,
             "frameStart": start,

--- a/client/ayon_blender/plugins/publish/extract_playblast.py
+++ b/client/ayon_blender/plugins/publish/extract_playblast.py
@@ -63,10 +63,12 @@ class ExtractPlayblast(
         self.log.debug(f"Outputting images to {path}")
         task_data = instance.data["anatomyData"].get("task", {})
         preset = get_capture_preset(
-            task_data.get("name"),
-            task_data.get("type"),
-            instance.data["productName"],
-            instance.context.data["project_settings"],
+            task_name=task_data.get("name"),
+            task_type=task_data.get("type"),
+            product_name=instance.data["productName"],
+            product_base_type=instance.data["productBaseType"],
+            project_settings=instance.context.data["project_settings"],
+            class_name=self.__name__,
             log=self.log
         )
         # additional required parameters for playblast

--- a/client/ayon_blender/plugins/publish/extract_playblast.py
+++ b/client/ayon_blender/plugins/publish/extract_playblast.py
@@ -47,10 +47,10 @@ class ExtractPlayblast(
         assert end >= start, "Invalid time range!"
 
         # get cameras
-        camera = instance.data("review_camera", None)
+        camera = instance.data.get("review_camera", None)
 
         # get isolate objects list
-        isolate = instance.data("isolate", None)
+        isolate = instance.data.get("isolate", None)
 
         # get output path
         stagingdir = self.staging_dir(instance)

--- a/client/ayon_blender/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_blender/plugins/publish/extract_thumbnail.py
@@ -1,10 +1,9 @@
 import os
 import glob
-import json
 
 import pyblish.api
 from ayon_blender.api import capture, plugin
-from ayon_blender.api.lib import maintained_time
+from ayon_blender.api.lib import maintained_time, get_capture_preset
 
 import bpy
 
@@ -21,7 +20,6 @@ class ExtractThumbnail(plugin.BlenderExtractor):
     hosts = ["blender"]
     families = ["review.playblast"]
     order = pyblish.api.ExtractorOrder + 0.01
-    presets = "{}"
 
     def process(self, instance):
         self.log.debug("Extracting capture..")
@@ -41,12 +39,17 @@ class ExtractThumbnail(plugin.BlenderExtractor):
 
         camera = instance.data.get("review_camera", "AUTO")
         start = instance.data.get("frameStart", bpy.context.scene.frame_start)
-        product_base_type = instance.data["productBaseType"]
         isolate = instance.data("isolate", None)
 
-        presets = json.loads(self.presets)
-        preset = presets.get(product_base_type, {})
-
+        task_data = instance.data["anatomyData"].get("task", {})
+        preset = get_capture_preset(
+            task_data.get("name"),
+            task_data.get("type"),
+            instance.data["productName"],
+            instance.context.data["project_settings"],
+            log=self.log
+        )
+        # additional required parameters for playblast
         preset.update({
             "camera": camera,
             "start_frame": start,
@@ -54,20 +57,26 @@ class ExtractThumbnail(plugin.BlenderExtractor):
             "filename": path,
             "overwrite": True,
             "isolate": isolate,
+            "log": self.log,
         })
-        preset.setdefault(
-            "image_settings",
-            {
-                "file_format": "JPEG",
-                "color_mode": "RGB",
-                "quality": 100,
-            },
-        )
 
+        # This would be removed after the transition of
+        # the new capture preset system.
+        if not preset.get("image_settings"):
+            preset.setdefault(
+                "image_settings",
+                {
+                    "file_format": "PNG",
+                    "color_mode": "RGB",
+                    "color_depth": "8",
+                    "compression": 15,
+                },
+            )
+        extension = preset["image_settings"].get("file_format", "PNG").lower()
         with maintained_time():
             path = capture(**preset)
 
-        thumbnail = os.path.basename(self._fix_output_path(path))
+        thumbnail = os.path.basename(self._fix_output_path(path, extension))
 
         self.log.debug(f"thumbnail: {thumbnail}")
 
@@ -75,14 +84,14 @@ class ExtractThumbnail(plugin.BlenderExtractor):
 
         representation = {
             "name": "thumbnail",
-            "ext": "jpg",
+            "ext": extension,
             "files": thumbnail,
             "stagingDir": stagingdir,
             "thumbnail": True
         }
         instance.data["representations"].append(representation)
 
-    def _fix_output_path(self, filepath):
+    def _fix_output_path(self, filepath, extension):
         """Workaround to return correct filepath.
 
         To workaround this we just glob.glob() for any file extensions and
@@ -98,7 +107,7 @@ class ExtractThumbnail(plugin.BlenderExtractor):
             return None
 
         if not os.path.exists(filepath):
-            files = glob.glob(f"{filepath}.*.jpg")
+            files = glob.glob(f"{filepath}.*.{extension}")
 
             if not files:
                 raise RuntimeError(f"Couldn't find playblast from: {filepath}")

--- a/client/ayon_blender/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_blender/plugins/publish/extract_thumbnail.py
@@ -43,10 +43,12 @@ class ExtractThumbnail(plugin.BlenderExtractor):
 
         task_data = instance.data["anatomyData"].get("task", {})
         preset = get_capture_preset(
-            task_data.get("name"),
-            task_data.get("type"),
-            instance.data["productName"],
-            instance.context.data["project_settings"],
+            task_name=task_data.get("name"),
+            task_type=task_data.get("type"),
+            product_name=instance.data["productName"],
+            product_base_type=instance.data["productBaseType"],
+            project_settings=instance.context.data["project_settings"],
+            class_name=self.__name__,
             log=self.log
         )
         # additional required parameters for playblast

--- a/client/ayon_blender/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_blender/plugins/publish/extract_thumbnail.py
@@ -39,7 +39,7 @@ class ExtractThumbnail(plugin.BlenderExtractor):
 
         camera = instance.data.get("review_camera", "AUTO")
         start = instance.data.get("frameStart", bpy.context.scene.frame_start)
-        isolate = instance.data("isolate", None)
+        isolate = instance.data.get("isolate", None)
 
         task_data = instance.data["anatomyData"].get("task", {})
         preset = get_capture_preset(

--- a/client/ayon_blender/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_blender/plugins/publish/extract_thumbnail.py
@@ -73,10 +73,12 @@ class ExtractThumbnail(plugin.BlenderExtractor):
                 },
             )
         extension = preset["image_settings"].get("file_format", "PNG").lower()
+        extension = "jpeg" if extension == "jpeg" else extension
         with maintained_time():
             path = capture(**preset)
 
         thumbnail = os.path.basename(self._fix_output_path(path, extension))
+        extension = os.path.splitext(thumbnail)[1].lstrip(".").lower()
 
         self.log.debug(f"thumbnail: {thumbnail}")
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,8 +1,8 @@
 from typing import Type
-
+from typing import Any
 from ayon_server.addons import BaseServerAddon
 
-from .settings import BlenderSettings, DEFAULT_VALUES
+from .settings import BlenderSettings, DEFAULT_VALUES, convert_settings_overrides
 
 
 class BlenderAddon(BaseServerAddon):
@@ -11,3 +11,14 @@ class BlenderAddon(BaseServerAddon):
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**DEFAULT_VALUES)
+
+    async def convert_settings_overrides(
+        self,
+        source_version: str,
+        overrides: dict[str, Any],
+    ) -> dict[str, Any]:
+        overrides = convert_settings_overrides(source_version, overrides)
+        # Use super conversion
+        return await super().convert_settings_overrides(
+            source_version, overrides
+        )

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -3,8 +3,11 @@ from .main import (
     DEFAULT_VALUES,
 )
 
+from .conversion import convert_settings_overrides
+
 
 __all__ = (
     "BlenderSettings",
     "DEFAULT_VALUES",
+    "convert_settings_overrides",
 )

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,0 +1,99 @@
+import json
+from typing import Any
+from semver import VersionInfo
+
+
+def _parse_legacy_preset(raw_preset: Any) -> dict[str, Any]:
+    if raw_preset is None:
+        return {}
+
+    if isinstance(raw_preset, str):
+        try:
+            parsed = json.loads(raw_preset)
+        except (TypeError, ValueError):
+            return {}
+    else:
+        parsed = raw_preset
+
+    if isinstance(parsed, dict):
+        return parsed
+
+    return {}
+
+
+def _convert_thumbnail_settings_model_1_1_8(
+        overrides: dict[str, Any], version: VersionInfo) -> None:
+    # Implement the conversion logic for thumbnail settings from version 0.4.11
+    if (version.major, version.minor, version.patch) > (1, 1, 8):
+        return
+
+    publish_settings = overrides.setdefault("publish", {})
+    extract_thumbnail_settings = publish_settings.setdefault(
+        "ExtractThumbnail", {}
+    )
+    capture_presets = extract_thumbnail_settings.get("presets", "{}")
+    parsed_presets = _parse_legacy_preset(capture_presets)
+    if not parsed_presets:
+        return
+
+    if extract_thumbnail_settings.get("profiles"):
+        return
+
+    extract_thumbnail_settings["profiles"] = []
+    for product_base_type in parsed_presets.keys():
+        extract_thumbnail_settings["profiles"].append(
+            {
+                "task_types": [],
+                "task_names": [],
+                "product_names": [],
+                "product_base_types": [product_base_type],
+                "presets": {
+                    **(parsed_presets.get(product_base_type) or {}),
+                    "additional_presets": "{}",
+                },
+            }
+        )
+
+    return overrides
+
+
+def _convert_playblast_settings_model_1_1_8(
+        overrides: dict[str, Any], version: VersionInfo) -> None:
+    # Implement the conversion logic for playblast settings from version 0.4.11
+    if (version.major, version.minor, version.patch) > (1, 1, 8):
+        return
+
+    publish_settings = overrides.setdefault("publish", {})
+    extract_playblast_settings = publish_settings.setdefault(
+        "ExtractPlayblast", {}
+    )
+    capture_presets = extract_playblast_settings.get("presets", "{}")
+    parsed_presets = _parse_legacy_preset(capture_presets)
+    if not parsed_presets:
+        return
+
+    if extract_playblast_settings.get("profiles"):
+        return
+
+    extract_playblast_settings["profiles"] = [{
+        "task_types": [],
+        "task_names": [],
+        "product_names": [],
+        "product_base_types": [],
+        "presets": {
+            **(parsed_presets.get("default") or {}),
+            "additional_presets": "{}",
+        },
+    }]
+
+    return overrides
+
+
+def convert_settings_overrides(
+    source_version: str,
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    version = VersionInfo.parse(source_version)
+    _convert_playblast_settings_model_1_1_8(overrides, version)
+    _convert_thumbnail_settings_model_1_1_8(overrides, version)
+    return overrides

--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -64,7 +64,6 @@ class ShadingSetting(BaseSettingsModel):
         title="Shading Type",
         enum_resolver=get_shading_type_enum
     )
-    render_pass: str = SettingsField("COMBINED", title="Render Pass")
 
 
 class DisplayOptionsSetting(BaseSettingsModel):

--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -23,11 +23,21 @@ def validate_json_dict(value):
         )
     return value
 
+
 def get_color_depth_enum():
     return [
         {"label": "8", "value": "8"},
         {"label": "16", "value": "16"},
         {"label": "32", "value": "32"},
+    ]
+
+
+def get_shading_type_enum():
+    return [
+        {"label": "Material", "value": "MATERIAL"},
+        {"label": "Solid", "value": "SOLID"},
+        {"label": "Wireframe", "value": "WIREFRAME"},
+        {"label": "Rendered", "value": "RENDERED"},
     ]
 
 class ImageSetting(BaseSettingsModel):
@@ -49,7 +59,11 @@ class OverlaySetting(BaseSettingsModel):
 
 class ShadingSetting(BaseSettingsModel):
     _layout = "expanded"
-    type: str = SettingsField("MATERIAL", title="Shading Type")
+    type: str = SettingsField(
+        "MATERIAL",
+        title="Shading Type",
+        enum_resolver=get_shading_type_enum
+    )
     render_pass: str = SettingsField("COMBINED", title="Render Pass")
 
 

--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -40,6 +40,26 @@ def get_shading_type_enum():
         {"label": "Rendered", "value": "RENDERED"},
     ]
 
+
+def get_shading_light_enum():
+    return [
+        {"label": "Studio", "value": "STUDIO"},
+        {"label": "Flat", "value": "FLAT"},
+        {"label": "Matcap", "value": "MATCAP"},
+    ]
+
+
+def get_color_type_enum():
+    return [
+        {"label": "Material", "value": "MATERIAL"},
+        {"label": "Object", "value": "OBJECT"},
+        {"label": "Random", "value": "RANDOM"},
+        {"label": "Vertex", "value": "VERTEX"},
+        {"label": "Texture", "value": "TEXTURE"},
+        {"label": "Single", "value": "SINGLE"},
+    ]
+
+
 class ImageSetting(BaseSettingsModel):
     _layout = "expanded"
     file_format: str = SettingsField("png", title="File Format")
@@ -55,15 +75,43 @@ class ImageSetting(BaseSettingsModel):
 class OverlaySetting(BaseSettingsModel):
     _layout = "expanded"
     show_overlays: bool = SettingsField(False, title="Show Overlays")
+    show_ortho_grid: bool = SettingsField(False, title="Show Ortho Grid")
+    show_floor: bool = SettingsField(False, title="Show Floor")
+    show_axis_x: bool = SettingsField(False, title="Show X Axis")
+    show_axis_y: bool = SettingsField(False, title="Show Y Axis")
+    show_axis_z: bool = SettingsField(False, title="Show Z Axis")
+    show_text: bool = SettingsField(False, title="Show Overlay Text")
+    show_stats: bool = SettingsField(False, title="Show Scene Stats")
+    show_cursor: bool = SettingsField(False, title="Show 3D Cursor")
+    show_annotation: bool = SettingsField(True, title="Show Annotations")
+    show_extras: bool = SettingsField(True, title="Show Extras Object details")
+    show_relationship_lines: bool = SettingsField(False, title="Show Relationship Lines")
+    show_outline_selected: bool = SettingsField(False, title="Show Outline Selected ")
+    show_motion_paths: bool = SettingsField(False, title="Show Motion Paths")
+    show_object_origins: bool = SettingsField(False, title="Show Object Origins")
+    show_bones: bool = SettingsField(False, title="Show Bones")
 
 
 class ShadingSetting(BaseSettingsModel):
     _layout = "expanded"
+    light: str = SettingsField(
+        "STUDIO",
+        title="Light",
+        enum_resolver=get_shading_light_enum
+    )
     type: str = SettingsField(
         "MATERIAL",
         title="Shading Type",
         enum_resolver=get_shading_type_enum
     )
+    color_type: str = SettingsField(
+        "MATERIAL",
+        title="Color Type",
+        enum_resolver=get_color_type_enum
+    )
+    show_xray: bool = SettingsField(False, title="Show X-Ray")
+    show_shadows: bool = SettingsField(False, title="Show Shadows")
+    show_cavity: bool = SettingsField(False, title="Show Cavity")
 
 
 class DisplayOptionsSetting(BaseSettingsModel):
@@ -109,6 +157,26 @@ class CapturePresetSetting(BaseSettingsModel):
         title="Camera Options",
         section="Camera Options"
     )
+    additional_presets: str = SettingsField(
+        "{}", title="Additional Presets",
+        widget="textarea"
+    )
+
+    @validator("additional_presets")
+    def validate_json(cls, value):
+        if not value.strip():
+            return "{}"
+        try:
+            converted_value = json.loads(value)
+            success = isinstance(converted_value, dict)
+        except json.JSONDecodeError:
+            success = False
+
+        if not success:
+            raise BadRequestException(
+                "The attibutes can't be parsed as json object"
+            )
+        return value
 
 
 class PlayblastProfilesModel(BaseSettingsModel):
@@ -123,6 +191,9 @@ class PlayblastProfilesModel(BaseSettingsModel):
     )
     product_names: list[str] = SettingsField(
         default_factory=list, title="Products names"
+    )
+    product_base_types: list[str] = SettingsField(
+        default_factory=list, title="Product Base Types"
     )
     presets: CapturePresetSetting = SettingsField(
         default_factory=CapturePresetSetting,
@@ -147,6 +218,8 @@ class ExtractPlayblastModel(BaseSettingsModel):
     def validate_json(cls, value):
         return validate_json_dict(value)
 
+
+
 DEFAULT_PLAYBLAST_SETTING = {
     "enabled": True,
     "optional": False,
@@ -157,8 +230,7 @@ DEFAULT_PLAYBLAST_SETTING = {
                 "image_settings": {
                     "file_format": "PNG",
                     "color_mode": "RGB",
-                    "color_depth": "8",
-                    "compression": 15
+
                 },
                 "display_options": {
                     "shading": {
@@ -174,4 +246,171 @@ DEFAULT_PLAYBLAST_SETTING = {
         indent=4
         ),
     "profiles": []
+}
+
+
+DEFAULT_THUMBNAIL_SETTING = {
+    "enabled": True,
+    "optional": True,
+    "active": True,
+    "presets": json.dumps(
+        {
+            "model": {
+                "image_settings": {
+                    "file_format": "PNG",
+                    "color_mode": "RGB"
+                },
+                "display_options": {
+                    "shading": {
+                        "light": "STUDIO",
+                        "studio_light": "Default",
+                        "type": "SOLID",
+                        "color_type": "OBJECT",
+                        "show_xray": False,
+                        "show_shadows": False,
+                        "show_cavity": True
+                    },
+                    "overlay": {
+                        "show_overlays": False
+                    }
+                }
+            },
+            "rig": {
+                "image_settings": {
+                    "file_format": "PNG",
+                    "color_mode": "RGB"
+                },
+                "display_options": {
+                    "shading": {
+                        "light": "STUDIO",
+                        "studio_light": "Default",
+                        "type": "SOLID",
+                        "color_type": "OBJECT",
+                        "show_xray": True,
+                        "show_shadows": False,
+                        "show_cavity": False
+                    },
+                    "overlay": {
+                        "show_overlays": True,
+                        "show_ortho_grid": False,
+                        "show_floor": False,
+                        "show_axis_x": False,
+                        "show_axis_y": False,
+                        "show_axis_z": False,
+                        "show_text": False,
+                        "show_stats": False,
+                        "show_cursor": False,
+                        "show_annotation": False,
+                        "show_extras": False,
+                        "show_relationship_lines": False,
+                        "show_outline_selected": False,
+                        "show_motion_paths": False,
+                        "show_object_origins": False,
+                        "show_bones": True
+                    }
+                }
+            }
+        },
+        indent=4,
+    ),
+    "profiles": [
+        {
+            "task_types": [],
+            "task_names": [],
+            "product_names": [],
+            "product_base_types": ["model"],
+            "presets": {
+                "image_settings": {
+                    "file_format": "PNG",
+                    "color_mode": "RGB",
+                    "color_depth": "8",
+                    "compression": 15
+                },
+                "resolution": {
+                    "width": 1920,
+                    "height": 1080,
+                    "maintain_aspect_ratio": True
+                },
+                "display_options": {
+                    "shading": {
+                        "light": "STUDIO",
+                        "studio_light": "Default",
+                        "type": "SOLID",
+                        "color_type": "OBJECT",
+                        "show_xray": False,
+                        "show_shadows": False,
+                        "show_cavity": True
+                    },
+                    "overlay": {
+                        "show_overlays": False,
+                        "show_ortho_grid": False,
+                        "show_floor": False,
+                        "show_axis_x": False,
+                        "show_axis_y": False,
+                        "show_axis_z": False,
+                        "show_text": False,
+                        "show_stats": False,
+                        "show_cursor": False,
+                        "show_annotation": False,
+                        "show_extras": False,
+                        "show_relationship_lines": False,
+                        "show_outline_selected": False,
+                        "show_motion_paths": False,
+                        "show_object_origins": False,
+                        "show_bones": False
+                    }
+                },
+                "additional_presets": "{}",
+            },
+        },
+        {
+            "task_types": [],
+            "task_names": [],
+            "product_names": [],
+            "product_base_types": ["rig"],
+            "presets": {
+                "image_settings": {
+                    "file_format": "PNG",
+                    "color_mode": "RGB",
+                    "color_depth": "8",
+                    "compression": 15
+                },
+                "resolution": {
+                    "width": 1920,
+                    "height": 1080,
+                    "maintain_aspect_ratio": True
+                },
+                "display_options": {
+                    "shading": {
+                        "light": "STUDIO",
+                        "studio_light": "Default",
+                        "type": "SOLID",
+                        "color_type": "OBJECT",
+                        "show_xray": True,
+                        "show_shadows": False,
+                        "show_cavity": True
+                    },
+                    "overlay": {
+                        "show_overlays": True,
+                        "show_ortho_grid": False,
+                        "show_floor": False,
+                        "show_axis_x": False,
+                        "show_axis_y": False,
+                        "show_axis_z": False,
+                        "show_text": False,
+                        "show_stats": False,
+                        "show_cursor": False,
+                        "show_annotation": False,
+                        "show_extras": False,
+                        "show_relationship_lines": False,
+                        "show_outline_selected": False,
+                        "show_motion_paths": False,
+                        "show_object_origins": False,
+                        "show_bones": True
+                    }
+                },
+                "additional_presets": "{}",
+            },
+        }
+    ]
 }

--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -132,9 +132,9 @@ class PlayblastProfilesModel(BaseSettingsModel):
 
 
 class ExtractPlayblastModel(BaseSettingsModel):
-    enabled: bool = SettingsField(title="Enabled")
-    optional: bool = SettingsField(title="Optional")
-    active: bool = SettingsField(title="Active")
+    enabled: bool = SettingsField(True, title="Enabled")
+    optional: bool = SettingsField(True, title="Optional")
+    active: bool = SettingsField(True, title="Active")
     presets: str = SettingsField(
         "", title="DEPRECATED! Please use \"Profiles\" below. Presets",
         widget="textarea"

--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -1,0 +1,164 @@
+import json
+from ayon_server.exceptions import BadRequestException
+from ayon_server.settings import (
+    BaseSettingsModel,
+    SettingsField,
+    task_types_enum,
+)
+from pydantic import validator
+
+
+def validate_json_dict(value):
+    if not value.strip():
+        return "{}"
+    try:
+        converted_value = json.loads(value)
+        success = isinstance(converted_value, dict)
+    except json.JSONDecodeError:
+        success = False
+
+    if not success:
+        raise BadRequestException(
+            "Environment's can't be parsed as json object"
+        )
+    return value
+
+def get_color_depth_enum():
+    return [
+        {"label": "8", "value": "8"},
+        {"label": "16", "value": "16"},
+        {"label": "32", "value": "32"},
+    ]
+
+class ImageSetting(BaseSettingsModel):
+    _layout = "expanded"
+    file_format: str = SettingsField("png", title="File Format")
+    color_mode: str = SettingsField("RGB", title="Color Mode")
+    color_depth: str = SettingsField(
+        "8",
+        title="Color Depth",
+        enum_resolver=get_color_depth_enum
+    )
+    compression: int = SettingsField(15, title="Compression")
+
+
+class OverlaySetting(BaseSettingsModel):
+    _layout = "expanded"
+    show_overlays: bool = SettingsField(False, title="Show Overlays")
+
+
+class ShadingSetting(BaseSettingsModel):
+    _layout = "expanded"
+    type: str = SettingsField("MATERIAL", title="Shading Type")
+    render_pass: str = SettingsField("COMBINED", title="Render Pass")
+
+
+class DisplayOptionsSetting(BaseSettingsModel):
+    _layout = "expanded"
+    shading: ShadingSetting = SettingsField(
+        default_factory=ShadingSetting,
+        title="Shading Options"
+    )
+    overlay: OverlaySetting = SettingsField(
+        default_factory=OverlaySetting,
+        title="Overlay Options"
+    )
+    show_gizmo: bool = SettingsField(False, title="Show Gizmo")
+
+
+class ResolutionSetting(BaseSettingsModel):
+    _layout = "expanded"
+    width: int = SettingsField(1920, title="Width")
+    height: int = SettingsField(1080, title="Height")
+    maintain_aspect_ratio: bool = SettingsField(True, title="Maintain Aspect Ratio")
+
+
+class CameraOptionsSetting(BaseSettingsModel):
+    background_images: bool = SettingsField(False, title="Show Background Images")
+
+
+class CapturePresetSetting(BaseSettingsModel):
+    image_settings: ImageSetting = SettingsField(
+        default_factory=ImageSetting,
+        title="Image Compression Settings",
+        section="Image Compression Settings")
+    resolution: ResolutionSetting = SettingsField(
+        default_factory=ResolutionSetting,
+        title="Resolution Settings",
+        section="Resolution Settings"
+    )
+    display_options: DisplayOptionsSetting = SettingsField(
+        default_factory=DisplayOptionsSetting,
+        title="Display Options",
+        section="Display Options")
+    camera_options: CameraOptionsSetting = SettingsField(
+        default_factory=CameraOptionsSetting,
+        title="Camera Options",
+        section="Camera Options"
+    )
+
+
+class PlayblastProfilesModel(BaseSettingsModel):
+    _layout = "expanded"
+    task_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Task types",
+        enum_resolver=task_types_enum
+    )
+    task_names: list[str] = SettingsField(
+        default_factory=list, title="Task names"
+    )
+    product_names: list[str] = SettingsField(
+        default_factory=list, title="Products names"
+    )
+    presets: CapturePresetSetting = SettingsField(
+        default_factory=CapturePresetSetting,
+        title="Capture Preset"
+    )
+
+
+class ExtractPlayblastModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="Enabled")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+    presets: str = SettingsField(
+        "", title="DEPRECATED! Please use \"Profiles\" below. Presets",
+        widget="textarea"
+    )
+    profiles: list[PlayblastProfilesModel] = SettingsField(
+        default_factory=list,
+        title="Profiles"
+    )
+
+    @validator("presets")
+    def validate_json(cls, value):
+        return validate_json_dict(value)
+
+DEFAULT_PLAYBLAST_SETTING = {
+    "enabled": True,
+    "optional": False,
+    "active": True,
+    "presets": json.dumps(
+        {
+            "default": {
+                "image_settings": {
+                    "file_format": "PNG",
+                    "color_mode": "RGB",
+                    "color_depth": "8",
+                    "compression": 15
+                },
+                "display_options": {
+                    "shading": {
+                        "type": "MATERIAL",
+                        "render_pass": "COMBINED"
+                    },
+                    "overlay": {
+                        "show_overlays": False
+                    }
+                }
+            }
+        },
+        indent=4
+        ),
+    "profiles": []
+}

--- a/server/settings/publish_playblast.py
+++ b/server/settings/publish_playblast.py
@@ -19,7 +19,7 @@ def validate_json_dict(value):
 
     if not success:
         raise BadRequestException(
-            "Environment's can't be parsed as json object"
+            "Presets can't be parsed as a JSON object"
         )
     return value
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1,5 +1,9 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
-from .publish_playblast import ExtractPlayblastModel, DEFAULT_PLAYBLAST_SETTING
+from .publish_playblast import (
+    ExtractPlayblastModel,
+    DEFAULT_PLAYBLAST_SETTING,
+    DEFAULT_THUMBNAIL_SETTING
+)
 
 
 class ValidatePluginModel(BaseSettingsModel):
@@ -274,8 +278,8 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=ValidatePluginModel,
         title="Extract Layout (JSON)"
     )
-    ExtractThumbnail: ValidatePluginModel = SettingsField(
-        default_factory=ValidatePluginModel,
+    ExtractThumbnail: ExtractPlayblastModel = SettingsField(
+        default_factory=ExtractPlayblastModel,
         title="Extract Thumbnail"
     )
     ExtractPlayblast: ExtractPlayblastModel = SettingsField(
@@ -422,11 +426,7 @@ DEFAULT_BLENDER_PUBLISH_SETTINGS = {
         "optional": True,
         "active": False
     },
-    "ExtractThumbnail": {
-        "enabled": True,
-        "optional": True,
-        "active": True,
-    },
+    "ExtractThumbnail": DEFAULT_THUMBNAIL_SETTING,
     "ExtractPlayblast": DEFAULT_PLAYBLAST_SETTING,
     "ExtractUSD": {
         "convert_orientation": False,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1,23 +1,5 @@
-import json
-from pydantic import validator
-from ayon_server.exceptions import BadRequestException
 from ayon_server.settings import BaseSettingsModel, SettingsField
-
-
-def validate_json_dict(value):
-    if not value.strip():
-        return "{}"
-    try:
-        converted_value = json.loads(value)
-        success = isinstance(converted_value, dict)
-    except json.JSONDecodeError:
-        success = False
-
-    if not success:
-        raise BadRequestException(
-            "Environment's can't be parsed as json object"
-        )
-    return value
+from .publish_playblast import ExtractPlayblastModel, DEFAULT_PLAYBLAST_SETTING
 
 
 class ValidatePluginModel(BaseSettingsModel):
@@ -178,18 +160,6 @@ class ExtractBlendAnimationModel(BaseSettingsModel):
     compress: bool = SettingsField(False, title="Compress")
 
 
-class ExtractPlayblastModel(BaseSettingsModel):
-    enabled: bool = SettingsField(True)
-    optional: bool = SettingsField(title="Optional")
-    active: bool = SettingsField(title="Active")
-    presets: str = SettingsField("", title="Presets", widget="textarea")
-    compress: bool = SettingsField(False, title="Compress")
-
-    @validator("presets")
-    def validate_json(cls, value):
-        return validate_json_dict(value)
-
-
 class PublishPluginsModel(BaseSettingsModel):
     ValidateAbsoluteDataBlockPaths: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
@@ -304,8 +274,8 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=ValidatePluginModel,
         title="Extract Layout (JSON)"
     )
-    ExtractThumbnail: ExtractPlayblastModel = SettingsField(
-        default_factory=ExtractPlayblastModel,
+    ExtractThumbnail: ValidatePluginModel = SettingsField(
+        default_factory=ValidatePluginModel,
         title="Extract Thumbnail"
     )
     ExtractPlayblast: ExtractPlayblastModel = SettingsField(
@@ -456,96 +426,8 @@ DEFAULT_BLENDER_PUBLISH_SETTINGS = {
         "enabled": True,
         "optional": True,
         "active": True,
-        "presets": json.dumps(
-            {
-                "model": {
-                    "image_settings": {
-                        "file_format": "JPEG",
-                        "color_mode": "RGB",
-                        "quality": 100
-                    },
-                    "display_options": {
-                        "shading": {
-                            "light": "STUDIO",
-                            "studio_light": "Default",
-                            "type": "SOLID",
-                            "color_type": "OBJECT",
-                            "show_xray": False,
-                            "show_shadows": False,
-                            "show_cavity": True
-                        },
-                        "overlay": {
-                            "show_overlays": False
-                        }
-                    }
-                },
-                "rig": {
-                    "image_settings": {
-                        "file_format": "JPEG",
-                        "color_mode": "RGB",
-                        "quality": 100
-                    },
-                    "display_options": {
-                        "shading": {
-                            "light": "STUDIO",
-                            "studio_light": "Default",
-                            "type": "SOLID",
-                            "color_type": "OBJECT",
-                            "show_xray": True,
-                            "show_shadows": False,
-                            "show_cavity": False
-                        },
-                        "overlay": {
-                            "show_overlays": True,
-                            "show_ortho_grid": False,
-                            "show_floor": False,
-                            "show_axis_x": False,
-                            "show_axis_y": False,
-                            "show_axis_z": False,
-                            "show_text": False,
-                            "show_stats": False,
-                            "show_cursor": False,
-                            "show_annotation": False,
-                            "show_extras": False,
-                            "show_relationship_lines": False,
-                            "show_outline_selected": False,
-                            "show_motion_paths": False,
-                            "show_object_origins": False,
-                            "show_bones": True
-                        }
-                    }
-                }
-            },
-            indent=4,
-        )
     },
-    "ExtractPlayblast": {
-        "enabled": True,
-        "optional": True,
-        "active": True,
-        "presets": json.dumps(
-            {
-                "default": {
-                    "image_settings": {
-                        "file_format": "PNG",
-                        "color_mode": "RGB",
-                        "color_depth": "8",
-                        "compression": 15
-                    },
-                    "display_options": {
-                        "shading": {
-                            "type": "MATERIAL",
-                            "render_pass": "COMBINED"
-                        },
-                        "overlay": {
-                            "show_overlays": False
-                        }
-                    }
-                }
-            },
-            indent=4
-        )
-    },
+    "ExtractPlayblast": DEFAULT_PLAYBLAST_SETTING,
     "ExtractUSD": {
         "convert_orientation": False,
         "export_animation": False,


### PR DESCRIPTION
## Changelog Description
This PR is to refactor the current review workflow and introduces the capture preset per profile for blender.
Resolve https://github.com/ynput/ayon-blender/issues/321

## Additional review information
We can discuss and improve the settings with this PR.
I also included the background image options as regards to https://github.com/ynput/ayon-blender/pull/320
## Testing notes:
1. Build addon with this branch
2. After the build, you would see the settings in `ayon+settings://blender/publish/ExtractPlayblast/profiles`
<img width="1051" height="667" alt="image" src="https://github.com/user-attachments/assets/911b53cc-02b5-4fd4-a511-e235f2a55bb4" />
3. Try to publish with blender