### PR TITLE
Teardown Qt UIs on Blender shutdown

### DIFF
--- a/client/ayon_blender/api/ops.py
+++ b/client/ayon_blender/api/ops.py
@@ -85,6 +85,38 @@ class BlenderApplication:
     def get_window(cls, identifier):
         return cls.blender_windows.get(identifier)
 
+    @classmethod
+    def shutdown(cls):
+        """Delete stored Qt windows before Blender tears down Qt."""
+        windows = list(cls.blender_windows.values())
+        cls.blender_windows.clear()
+
+        unique_windows = []
+        seen_ids = set()
+        for window in windows:
+            if not isinstance(window, QtWidgets.QWidget):
+                continue
+            window_id = id(window)
+            if window_id in seen_ids:
+                continue
+            seen_ids.add(window_id)
+            unique_windows.append(window)
+
+        for window in unique_windows:
+            window.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
+            window.close()
+            window.deleteLater()
+
+        application = cls._instance or QtWidgets.QApplication.instance()
+        if application is not None:
+            application.sendPostedEvents(
+                None,
+                QtCore.QEvent.DeferredDelete,
+            )
+            application.processEvents()
+
+        cls._instance = None
+
 
 class MainThreadItem:
     """Structure to store information about callback in main thread.
@@ -651,6 +683,14 @@ def register():
 
 def unregister():
     """Unregister the operators and menu."""
+
+    from ayon_core.ui.components.task_queue import shutdown_task_queue
+
+    if bpy.app.timers.is_registered(_process_app_events):
+        bpy.app.timers.unregister(_process_app_events)
+    shutdown_task_queue()
+    BlenderApplication.shutdown()
+    GlobalClass.app = None
 
     pcoll = PREVIEW_COLLECTIONS.pop("ayon")
     bpy.utils.previews.remove(pcoll)


### PR DESCRIPTION
## Changelog Description

When Blender shuts down it directly takes down the UIs while still keep an handle to then (they are e.g. on `blender_windows` class attribute). Instead, perform a full teardown of the Qt UIs to avoid Blender in some cases to throw an error dialog saying that "Blender stopped working" when you're exiting blender with an AYON UI opened.

## Additional review information

No errors should happen on Blender shutdown. Some errors would be quite common to occur with the new browser, because the new browser internally also keeps some QStyle references that seem too linger a bit too long for Qt's taste upon the Blender shutdown.

## Testing notes:

1. Shutting down Blender should not cause any issues (e.g. slow shutdowns)
2. Blender should shutdown without any errors.